### PR TITLE
Add basic chess AI skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# Test
+# Chess AI Skeleton
+
+This repository contains a minimal Python skeleton for a self-learning chess engine.
+The code implements basic components described in the included specification:
+
+- **GameEnvironment** using `python-chess` for rule handling and board encoding
+- **PolicyValueNet** with a residual convolutional architecture
+- **MCTS** search using neural network priors and value estimates
+- **ReplayBuffer** to store training examples
+- **Trainer** performing simple policy/value updates
+- **Self-play** routine for data generation
+
+This code is only a starting point and omits many details required for a
+production-ready system, but demonstrates the overall structure.
+

--- a/README.md
+++ b/README.md
@@ -13,3 +13,14 @@ The code implements basic components described in the included specification:
 This code is only a starting point and omits many details required for a
 production-ready system, but demonstrates the overall structure.
 
+## Usage
+
+Install requirements and run a short self-play session:
+
+```bash
+pip install torch python-chess
+python -m chess_ai.self_play
+```
+
+Adjust hyperparameters in `chess_ai/config.py` to tune the behaviour.
+

--- a/chess_ai/__init__.py
+++ b/chess_ai/__init__.py
@@ -1,0 +1,7 @@
+"""Chess AI skeleton package."""
+
+from .game_environment import GameEnvironment
+from .policy_value_net import PolicyValueNet
+from .mcts import MCTS
+from .replay_buffer import ReplayBuffer
+from .trainer import Trainer

--- a/chess_ai/__init__.py
+++ b/chess_ai/__init__.py
@@ -5,3 +5,4 @@ from .policy_value_net import PolicyValueNet
 from .mcts import MCTS
 from .replay_buffer import ReplayBuffer
 from .trainer import Trainer
+from .config import Config

--- a/chess_ai/config.py
+++ b/chess_ai/config.py
@@ -1,0 +1,25 @@
+class Config:
+    """Central configuration for the chess AI."""
+
+    # Paths
+    CHECKPOINT_DIR = "checkpoints"
+    REPLAY_BUFFER_SIZE = 100_000
+
+    # Hardware
+    DEVICE = "cuda" if __import__('torch').cuda.is_available() else "cpu"
+    SEED = 42
+
+    # MCTS parameters
+    NUM_SIMULATIONS = 800
+    C_PUCT = 1.5
+    DIRICHLET_EPSILON = 0.25
+    DIRICHLET_ALPHA = 0.03
+
+    # Network parameters
+    NUM_RES_BLOCKS = 19
+    NUM_FILTERS = 256
+    LEARNING_RATE = 0.01
+    BATCH_SIZE = 32
+    WEIGHT_DECAY = 1e-4
+    MOMENTUM = 0.9
+

--- a/chess_ai/evaluation.py
+++ b/chess_ai/evaluation.py
@@ -1,14 +1,16 @@
 import chess
+
 from .game_environment import GameEnvironment
 from .mcts import MCTS
+from .config import Config
 
 
-def evaluate(net_a, net_b, num_games=10, num_simulations=100):
+def evaluate(net_a, net_b, num_games: int = 10, num_simulations: int = Config.NUM_SIMULATIONS):
     stats = {"wins": 0, "losses": 0, "draws": 0}
     for g in range(num_games):
         env = GameEnvironment()
         current_player = 1
-        nets = [net_a, net_b]
+        nets = [net_a.to(Config.DEVICE), net_b.to(Config.DEVICE)]
         while True:
             net = nets[0] if env.board.turn == chess.WHITE else nets[1]
             mcts = MCTS(net, num_simulations=num_simulations)

--- a/chess_ai/evaluation.py
+++ b/chess_ai/evaluation.py
@@ -1,0 +1,30 @@
+import chess
+from .game_environment import GameEnvironment
+from .mcts import MCTS
+
+
+def evaluate(net_a, net_b, num_games=10, num_simulations=100):
+    stats = {"wins": 0, "losses": 0, "draws": 0}
+    for g in range(num_games):
+        env = GameEnvironment()
+        current_player = 1
+        nets = [net_a, net_b]
+        while True:
+            net = nets[0] if env.board.turn == chess.WHITE else nets[1]
+            mcts = MCTS(net, num_simulations=num_simulations)
+            visit_counts = mcts.run(env.get_state())
+            best_move_idx = max(visit_counts, key=visit_counts.get)
+            move = list(env.legal_moves())[best_move_idx]
+            _, reward, done = env.step(move)
+            if done:
+                if reward == 1:
+                    stats["wins"] += 1 if env.board.turn == chess.BLACK else 0
+                    stats["losses"] += 1 if env.board.turn == chess.WHITE else 0
+                elif reward == -1:
+                    stats["losses"] += 1 if env.board.turn == chess.BLACK else 0
+                    stats["wins"] += 1 if env.board.turn == chess.WHITE else 0
+                else:
+                    stats["draws"] += 1
+                break
+            current_player *= -1
+    return stats

--- a/chess_ai/game_environment.py
+++ b/chess_ai/game_environment.py
@@ -5,7 +5,7 @@ import numpy as np
 class GameEnvironment:
     """Wrapper around python-chess for board management and encoding."""
 
-    NUM_CHANNELS = 17
+    NUM_CHANNELS = 18
 
     def __init__(self):
         self.board = chess.Board()
@@ -39,7 +39,7 @@ class GameEnvironment:
 
     @classmethod
     def encode_board(cls, board: chess.Board):
-        """Encode board into 8x8x17 numpy tensor."""
+        """Encode board into an 8x8x18 tensor of binary features."""
         planes = np.zeros((cls.NUM_CHANNELS, 8, 8), dtype=np.float32)
         piece_map = board.piece_map()
         for square, piece in piece_map.items():
@@ -60,4 +60,8 @@ class GameEnvironment:
         planes[14][:] = int(board.has_queenside_castling_rights(chess.WHITE))
         planes[15][:] = int(board.has_kingside_castling_rights(chess.BLACK))
         planes[16][:] = int(board.has_queenside_castling_rights(chess.BLACK))
+        if board.ep_square is not None:
+            row = board.ep_square // 8
+            col = board.ep_square % 8
+            planes[17][row][col] = 1
         return planes

--- a/chess_ai/game_environment.py
+++ b/chess_ai/game_environment.py
@@ -1,0 +1,63 @@
+import chess
+import numpy as np
+
+
+class GameEnvironment:
+    """Wrapper around python-chess for board management and encoding."""
+
+    NUM_CHANNELS = 17
+
+    def __init__(self):
+        self.board = chess.Board()
+
+    def reset(self):
+        self.board.reset()
+        return self.get_state()
+
+    def get_state(self):
+        return self.encode_board(self.board)
+
+    def legal_moves(self):
+        return list(self.board.legal_moves)
+
+    def step(self, move):
+        self.board.push(move)
+        done = self.board.is_game_over()
+        reward = 0.0
+        if done:
+            result = self.board.result()
+            if result == '1-0':
+                reward = 1.0
+            elif result == '0-1':
+                reward = -1.0
+            else:
+                reward = 0.0
+        return self.get_state(), reward, done
+
+    def undo(self):
+        self.board.pop()
+
+    @classmethod
+    def encode_board(cls, board: chess.Board):
+        """Encode board into 8x8x17 numpy tensor."""
+        planes = np.zeros((cls.NUM_CHANNELS, 8, 8), dtype=np.float32)
+        piece_map = board.piece_map()
+        for square, piece in piece_map.items():
+            row = square // 8
+            col = square % 8
+            offset = 0 if piece.color == chess.WHITE else 6
+            piece_idx = {
+                chess.PAWN: 0,
+                chess.ROOK: 1,
+                chess.KNIGHT: 2,
+                chess.BISHOP: 3,
+                chess.QUEEN: 4,
+                chess.KING: 5,
+            }[piece.piece_type]
+            planes[offset + piece_idx][row][col] = 1
+        planes[12][:] = int(board.turn)
+        planes[13][:] = int(board.has_kingside_castling_rights(chess.WHITE))
+        planes[14][:] = int(board.has_queenside_castling_rights(chess.WHITE))
+        planes[15][:] = int(board.has_kingside_castling_rights(chess.BLACK))
+        planes[16][:] = int(board.has_queenside_castling_rights(chess.BLACK))
+        return planes

--- a/chess_ai/mcts.py
+++ b/chess_ai/mcts.py
@@ -1,0 +1,75 @@
+import math
+from collections import defaultdict
+
+import numpy as np
+import torch
+
+
+class MCTSNode:
+    def __init__(self, state, parent=None):
+        self.state = state
+        self.parent = parent
+        self.children = {}
+        self.P = {}
+        self.N = defaultdict(int)
+        self.W = defaultdict(float)
+        self.Q = defaultdict(float)
+        self.is_expanded = False
+
+    def expand(self, policy, legal_moves):
+        for move in legal_moves:
+            idx = move
+            self.P[move] = policy[idx]
+            self.N[move] = 0
+            self.W[move] = 0.0
+            self.Q[move] = 0.0
+        self.is_expanded = True
+
+    def select(self, c_puct):
+        total_visits = sum(self.N[m] for m in self.P)
+        best_move, best_score = None, -float('inf')
+        for move in self.P:
+            u = self.Q[move] + c_puct * self.P[move] * math.sqrt(total_visits) / (1 + self.N[move])
+            if u > best_score:
+                best_score = u
+                best_move = move
+        return best_move
+
+
+class MCTS:
+    def __init__(self, network, c_puct=1.5, num_simulations=800):
+        self.network = network
+        self.c_puct = c_puct
+        self.num_simulations = num_simulations
+
+    def run(self, root_state):
+        root = MCTSNode(root_state)
+        state_tensor = torch.tensor(root_state, dtype=torch.float32).unsqueeze(0)
+        with torch.no_grad():
+            log_p, v = self.network(state_tensor)
+        policy = torch.exp(log_p[0]).cpu().numpy()
+        root.expand(policy, range(len(policy)))
+
+        for _ in range(self.num_simulations):
+            node = root
+            search_path = []
+            while node.is_expanded:
+                move = node.select(self.c_puct)
+                search_path.append((node, move))
+                if move not in node.children:
+                    break
+                node = node.children[move]
+            # evaluation
+            if not node.is_expanded:
+                state_tensor = torch.tensor(node.state, dtype=torch.float32).unsqueeze(0)
+                with torch.no_grad():
+                    log_p, v = self.network(state_tensor)
+                policy = torch.exp(log_p[0]).cpu().numpy()
+                node.expand(policy, range(len(policy)))
+            value = v.item()
+            for parent, move in reversed(search_path):
+                parent.N[move] += 1
+                parent.W[move] += value
+                parent.Q[move] = parent.W[move] / parent.N[move]
+                value = -value
+        return {m: root.N[m] for m in root.P}

--- a/chess_ai/network_manager.py
+++ b/chess_ai/network_manager.py
@@ -3,9 +3,11 @@ from glob import glob
 
 import torch
 
+from .config import Config
+
 
 class NetworkManager:
-    def __init__(self, checkpoint_dir="checkpoints"):
+    def __init__(self, checkpoint_dir: str = Config.CHECKPOINT_DIR):
         self.checkpoint_dir = checkpoint_dir
         os.makedirs(self.checkpoint_dir, exist_ok=True)
 

--- a/chess_ai/network_manager.py
+++ b/chess_ai/network_manager.py
@@ -1,0 +1,21 @@
+import os
+from glob import glob
+
+import torch
+
+
+class NetworkManager:
+    def __init__(self, checkpoint_dir="checkpoints"):
+        self.checkpoint_dir = checkpoint_dir
+        os.makedirs(self.checkpoint_dir, exist_ok=True)
+
+    def latest_checkpoint(self):
+        files = glob(os.path.join(self.checkpoint_dir, "*.pt"))
+        if not files:
+            return None
+        return max(files, key=os.path.getmtime)
+
+    def save(self, model, optimizer, name):
+        path = os.path.join(self.checkpoint_dir, f"{name}.pt")
+        torch.save({"model_state": model.state_dict(), "optim_state": optimizer.state_dict()}, path)
+        return path

--- a/chess_ai/policy_value_net.py
+++ b/chess_ai/policy_value_net.py
@@ -36,6 +36,18 @@ class PolicyValueNet(nn.Module):
         self.fc_value1 = nn.Linear(1 * 8 * 8, 256)
         self.fc_value2 = nn.Linear(256, 1)
 
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight, mode="fan_out", nonlinearity="relu")
+                if m.bias is not None:
+                    nn.init.constant_(m.bias, 0)
+            elif isinstance(m, nn.Linear):
+                nn.init.kaiming_uniform_(m.weight, a=0.01)
+                nn.init.constant_(m.bias, 0)
+            elif isinstance(m, nn.BatchNorm2d):
+                nn.init.constant_(m.weight, 1)
+                nn.init.constant_(m.bias, 0)
+
     def forward(self, x):
         x = F.relu(self.bn0(self.conv0(x)))
         for block in self.res_blocks:

--- a/chess_ai/policy_value_net.py
+++ b/chess_ai/policy_value_net.py
@@ -1,0 +1,50 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class ResidualBlock(nn.Module):
+    def __init__(self, filters: int):
+        super().__init__()
+        self.conv1 = nn.Conv2d(filters, filters, kernel_size=3, padding=1)
+        self.bn1 = nn.BatchNorm2d(filters)
+        self.conv2 = nn.Conv2d(filters, filters, kernel_size=3, padding=1)
+        self.bn2 = nn.BatchNorm2d(filters)
+
+    def forward(self, x):
+        identity = x
+        out = F.relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+        out += identity
+        out = F.relu(out)
+        return out
+
+
+class PolicyValueNet(nn.Module):
+    def __init__(self, in_channels: int, action_size: int, num_blocks: int = 19, filters: int = 256):
+        super().__init__()
+        self.conv0 = nn.Conv2d(in_channels, filters, kernel_size=3, padding=1)
+        self.bn0 = nn.BatchNorm2d(filters)
+        self.res_blocks = nn.ModuleList([ResidualBlock(filters) for _ in range(num_blocks)])
+        # policy head
+        self.conv_policy = nn.Conv2d(filters, 2, kernel_size=1)
+        self.bn_policy = nn.BatchNorm2d(2)
+        self.fc_policy = nn.Linear(2 * 8 * 8, action_size)
+        # value head
+        self.conv_value = nn.Conv2d(filters, 1, kernel_size=1)
+        self.bn_value = nn.BatchNorm2d(1)
+        self.fc_value1 = nn.Linear(1 * 8 * 8, 256)
+        self.fc_value2 = nn.Linear(256, 1)
+
+    def forward(self, x):
+        x = F.relu(self.bn0(self.conv0(x)))
+        for block in self.res_blocks:
+            x = block(x)
+        p = F.relu(self.bn_policy(self.conv_policy(x)))
+        p = p.view(p.size(0), -1)
+        p = F.log_softmax(self.fc_policy(p), dim=1)
+        v = F.relu(self.bn_value(self.conv_value(x)))
+        v = v.view(v.size(0), -1)
+        v = F.relu(self.fc_value1(v))
+        v = torch.tanh(self.fc_value2(v))
+        return p, v

--- a/chess_ai/replay_buffer.py
+++ b/chess_ai/replay_buffer.py
@@ -1,0 +1,18 @@
+import random
+from collections import deque
+
+
+class ReplayBuffer:
+    def __init__(self, capacity=100000):
+        self.buffer = deque(maxlen=capacity)
+
+    def add(self, state, policy, value):
+        self.buffer.append((state, policy, value))
+
+    def sample(self, batch_size):
+        batch = random.sample(self.buffer, batch_size)
+        states, policies, values = zip(*batch)
+        return states, policies, values
+
+    def __len__(self):
+        return len(self.buffer)

--- a/chess_ai/replay_buffer.py
+++ b/chess_ai/replay_buffer.py
@@ -1,9 +1,11 @@
 import random
 from collections import deque
 
+from .config import Config
+
 
 class ReplayBuffer:
-    def __init__(self, capacity=100000):
+    def __init__(self, capacity: int = Config.REPLAY_BUFFER_SIZE):
         self.buffer = deque(maxlen=capacity)
 
     def add(self, state, policy, value):

--- a/chess_ai/self_play.py
+++ b/chess_ai/self_play.py
@@ -1,0 +1,26 @@
+import numpy as np
+import torch
+
+from .game_environment import GameEnvironment
+from .mcts import MCTS
+
+
+def run_self_play(network, num_simulations=50):
+    env = GameEnvironment()
+    mcts = MCTS(network, num_simulations=num_simulations)
+    state = env.reset()
+    trajectory = []
+    current_player = 1
+    while True:
+        visit_counts = mcts.run(state)
+        pi = np.array(list(visit_counts.values()), dtype=np.float32)
+        best_move_idx = max(visit_counts, key=visit_counts.get)
+        move = list(env.legal_moves())[best_move_idx]
+        trajectory.append((state, pi, current_player))
+        state, reward, done = env.step(move)
+        if done:
+            for s, p, player in trajectory:
+                z = reward if player == current_player else -reward
+                yield s, p, z
+            break
+        current_player *= -1

--- a/chess_ai/self_play.py
+++ b/chess_ai/self_play.py
@@ -3,10 +3,13 @@ import torch
 
 from .game_environment import GameEnvironment
 from .mcts import MCTS
+from .config import Config
 
 
-def run_self_play(network, num_simulations=50):
+def run_self_play(network, num_simulations: int = Config.NUM_SIMULATIONS):
+    """Generate self-play data from games played by the network."""
     env = GameEnvironment()
+    network = network.to(Config.DEVICE)
     mcts = MCTS(network, num_simulations=num_simulations)
     state = env.reset()
     trajectory = []

--- a/chess_ai/trainer.py
+++ b/chess_ai/trainer.py
@@ -1,28 +1,37 @@
+"""Training utilities for the chess network."""
+
 from typing import Iterable
 
 import torch
 from torch.utils.data import DataLoader, TensorDataset
 
+from .config import Config
+
 
 class Trainer:
-    def __init__(self, network, buffer, optimizer, batch_size=32, epochs=1):
-        self.network = network
+    def __init__(self, network, buffer, optimizer, batch_size: int = Config.BATCH_SIZE, epochs: int = 1):
+        self.network = network.to(Config.DEVICE)
         self.buffer = buffer
         self.optimizer = optimizer
         self.batch_size = batch_size
         self.epochs = epochs
 
     def train(self):
+        """Train the network for one epoch using data from the replay buffer."""
+
         if len(self.buffer) < self.batch_size:
             return
         states, policies, values = self.buffer.sample(self.batch_size)
-        states = torch.tensor(states, dtype=torch.float32)
-        policies = torch.tensor(policies, dtype=torch.float32)
-        values = torch.tensor(values, dtype=torch.float32)
+        states = torch.tensor(states, dtype=torch.float32, device=Config.DEVICE)
+        policies = torch.tensor(policies, dtype=torch.float32, device=Config.DEVICE)
+        values = torch.tensor(values, dtype=torch.float32, device=Config.DEVICE)
         dataset = TensorDataset(states, policies, values)
         loader = DataLoader(dataset, batch_size=self.batch_size, shuffle=True)
         for _ in range(self.epochs):
             for s, p_target, v_target in loader:
+                s = s.to(Config.DEVICE)
+                p_target = p_target.to(Config.DEVICE)
+                v_target = v_target.to(Config.DEVICE)
                 log_p, v = self.network(s)
                 loss_policy = -(p_target * log_p).sum(dim=1).mean()
                 loss_value = torch.mean((v.view(-1) - v_target)**2)

--- a/chess_ai/trainer.py
+++ b/chess_ai/trainer.py
@@ -1,0 +1,32 @@
+from typing import Iterable
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+
+class Trainer:
+    def __init__(self, network, buffer, optimizer, batch_size=32, epochs=1):
+        self.network = network
+        self.buffer = buffer
+        self.optimizer = optimizer
+        self.batch_size = batch_size
+        self.epochs = epochs
+
+    def train(self):
+        if len(self.buffer) < self.batch_size:
+            return
+        states, policies, values = self.buffer.sample(self.batch_size)
+        states = torch.tensor(states, dtype=torch.float32)
+        policies = torch.tensor(policies, dtype=torch.float32)
+        values = torch.tensor(values, dtype=torch.float32)
+        dataset = TensorDataset(states, policies, values)
+        loader = DataLoader(dataset, batch_size=self.batch_size, shuffle=True)
+        for _ in range(self.epochs):
+            for s, p_target, v_target in loader:
+                log_p, v = self.network(s)
+                loss_policy = -(p_target * log_p).sum(dim=1).mean()
+                loss_value = torch.mean((v.view(-1) - v_target)**2)
+                loss = loss_policy + loss_value
+                self.optimizer.zero_grad()
+                loss.backward()
+                self.optimizer.step()

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,0 +1,10 @@
+import numpy as np
+from chess_ai.game_environment import GameEnvironment
+
+
+def test_initial_board_has_correct_channels():
+    env = GameEnvironment()
+    state = env.get_state()
+    assert state.shape == (GameEnvironment.NUM_CHANNELS, 8, 8)
+    # Check that side to move plane sums to 64 since all ones or zeros are uniform
+    assert state[12].max() in (0, 1)


### PR DESCRIPTION
## Summary
- build GameEnvironment to encode boards with python-chess
- implement basic residual PolicyValueNet
- add simple MCTS, replay buffer, trainer and self-play modules
- include a gitignore and README description

## Testing
- `python3 -m compileall -q chess_ai`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ff504c6b4832591906bd1b7d2828c