### PR TITLE
Enable chess.Move-based MCTS

### DIFF
--- a/chess_ai/action_index.py
+++ b/chess_ai/action_index.py
@@ -1,0 +1,18 @@
+import chess
+
+PROMOTIONS = [None, chess.QUEEN, chess.ROOK, chess.BISHOP, chess.KNIGHT]
+ACTION_SIZE = 64 * 64 * len(PROMOTIONS)
+
+
+def move_to_index(move: chess.Move) -> int:
+    promo_idx = PROMOTIONS.index(move.promotion)
+    return ((move.from_square * 64) + move.to_square) * len(PROMOTIONS) + promo_idx
+
+
+def index_to_move(index: int) -> chess.Move:
+    promo_idx = index % len(PROMOTIONS)
+    idx = index // len(PROMOTIONS)
+    from_sq = idx // 64
+    to_sq = idx % 64
+    promotion = PROMOTIONS[promo_idx]
+    return chess.Move(from_sq, to_sq, promotion=promotion)

--- a/chess_ai/self_play.py
+++ b/chess_ai/self_play.py
@@ -4,6 +4,7 @@ import torch
 from .game_environment import GameEnvironment
 from .mcts import MCTS
 from .config import Config
+from .action_index import ACTION_SIZE, index_to_move
 
 
 def run_self_play(network, num_simulations: int = Config.NUM_SIMULATIONS):
@@ -15,10 +16,12 @@ def run_self_play(network, num_simulations: int = Config.NUM_SIMULATIONS):
     trajectory = []
     current_player = 1
     while True:
-        visit_counts = mcts.run(state)
-        pi = np.array(list(visit_counts.values()), dtype=np.float32)
+        visit_counts = mcts.run(env.board)
+        pi = np.zeros(ACTION_SIZE, dtype=np.float32)
+        for idx, c in visit_counts.items():
+            pi[idx] = c
         best_move_idx = max(visit_counts, key=visit_counts.get)
-        move = list(env.legal_moves())[best_move_idx]
+        move = index_to_move(best_move_idx)
         trajectory.append((state, pi, current_player))
         state, reward, done = env.step(move)
         if done:

--- a/tests/test_mcts.py
+++ b/tests/test_mcts.py
@@ -1,0 +1,29 @@
+import chess
+import torch
+
+from chess_ai.mcts import MCTS
+from chess_ai.action_index import move_to_index, index_to_move, ACTION_SIZE
+
+
+class DummyNet(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        batch = x.size(0)
+        log_p = torch.log_softmax(torch.ones(batch, ACTION_SIZE), dim=1)
+        v = torch.zeros(batch, 1)
+        return log_p, v
+
+
+def test_mcts_returns_valid_move_indices():
+    board = chess.Board()
+    net = DummyNet()
+    mcts = MCTS(net, num_simulations=2)
+    visit_counts = mcts.run(board)
+
+    legal_indices = {move_to_index(m) for m in board.legal_moves}
+    assert set(visit_counts.keys()) == legal_indices
+    for idx in visit_counts:
+        move = index_to_move(idx)
+        assert move in board.legal_moves


### PR DESCRIPTION
## Summary
- map chess.Move objects to unique action indices
- update Monte Carlo tree search to operate directly on chess boards
- adapt self-play to use the global move index mapping
- add tests checking that MCTS outputs indices for legal moves

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'torch._C')*

------
https://chatgpt.com/codex/tasks/task_e_6840130d51b88325914ebaaa5dc669b8