### PR TITLE
Implement policy training and doc update

### DIFF
--- a/superengine/docs/design.md
+++ b/superengine/docs/design.md
@@ -1,1 +1,11 @@
 # SuperEngine Design
+
+## Training Data Format
+
+`selfplay_ray.py` stores each finished game as a PGN file in the `games/` directory.  `train_policy.py` expects these PGN files as input.  For every move in the main line of each game the following tuple is generated:
+
+1. **State** – an `8x8x18` tensor created with `GameEnvironment.encode_board` representing the board before the move.
+2. **Policy** – a one‑hot vector of length `ACTION_SIZE` where the played move index (via `move_to_index`) is `1`.
+3. **Value** – the final game outcome from the perspective of the player to move at that state (`1` for win, `0` for draw, `-1` for loss).
+
+The resulting tensors are fed to the PyTorch‑Lightning training loop in `train_policy.py`.

--- a/superengine/scripts/train_policy.py
+++ b/superengine/scripts/train_policy.py
@@ -1,1 +1,76 @@
-# Placeholder for policy training script
+import glob
+import os
+import chess
+import chess.pgn
+import numpy as np
+import torch
+import lightning as L
+from torch.utils.data import DataLoader, TensorDataset
+
+from chess_ai.game_environment import GameEnvironment
+from chess_ai.policy_value_net import PolicyValueNet
+from chess_ai.action_index import ACTION_SIZE, move_to_index
+
+
+def load_games(game_dir: str):
+    """Load PGN files from ``game_dir`` and return tensors for training."""
+    states, policies, values = [], [], []
+    for pgn_file in glob.glob(os.path.join(game_dir, "*.pgn")):
+        with open(pgn_file) as fh:
+            while True:
+                game = chess.pgn.read_game(fh)
+                if game is None:
+                    break
+                result = game.headers.get("Result", "1/2-1/2")
+                if result == "1-0":
+                    winner = 1
+                elif result == "0-1":
+                    winner = -1
+                else:
+                    winner = 0
+                board = game.board()
+                for move in game.mainline_moves():
+                    state = GameEnvironment.encode_board(board)
+                    policy = np.zeros(ACTION_SIZE, dtype=np.float32)
+                    policy[move_to_index(move)] = 1.0
+                    value = winner if board.turn == chess.WHITE else -winner
+                    states.append(state)
+                    policies.append(policy)
+                    values.append(value)
+                    board.push(move)
+    states = torch.tensor(np.array(states), dtype=torch.float32)
+    policies = torch.tensor(np.array(policies), dtype=torch.float32)
+    values = torch.tensor(np.array(values), dtype=torch.float32)
+    return TensorDataset(states, policies, values)
+
+
+class Module(L.LightningModule):
+    def __init__(self):
+        super().__init__()
+        self.net = PolicyValueNet(GameEnvironment.NUM_CHANNELS, ACTION_SIZE)
+        self.loss_mse = torch.nn.MSELoss()
+
+    def training_step(self, batch, _):
+        s, p_target, v_target = batch
+        log_p, v = self.net(s)
+        loss_p = -(p_target * log_p).sum(dim=1).mean()
+        loss_v = self.loss_mse(v.view(-1), v_target)
+        loss = loss_p + loss_v
+        self.log_dict({"loss": loss, "policy_loss": loss_p, "value_loss": loss_v})
+        return loss
+
+    def configure_optimizers(self):
+        return torch.optim.AdamW(self.parameters(), lr=1e-3)
+
+
+def main():
+    dataset = load_games("games")
+    loader = DataLoader(dataset, batch_size=256, shuffle=True, num_workers=4)
+    trainer = L.Trainer(max_epochs=5, devices=1 if not torch.cuda.is_available() else torch.cuda.device_count(), accelerator="gpu" if torch.cuda.is_available() else "cpu")
+    trainer.fit(Module(), loader)
+    os.makedirs("../nets", exist_ok=True)
+    torch.save(trainer.model.net.state_dict(), "../nets/gpu_policy.onnx")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- flesh out `train_policy.py` with a PyTorch-Lightning loop
- add PGN-based dataset loader
- document training data format in `design.md`

## Testing
- `pip install torch python-chess numpy lightning -q`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68414b86f7e08325b9bcf659423b683e