### PR TITLE
Fix evaluate board usage and add test

### DIFF
--- a/chess_ai/evaluation.py
+++ b/chess_ai/evaluation.py
@@ -3,6 +3,7 @@ import chess
 from .game_environment import GameEnvironment
 from .mcts import MCTS
 from .config import Config
+from .action_index import index_to_move
 
 
 def evaluate(net_a, net_b, num_games: int = 10, num_simulations: int = Config.NUM_SIMULATIONS):
@@ -14,9 +15,9 @@ def evaluate(net_a, net_b, num_games: int = 10, num_simulations: int = Config.NU
         while True:
             net = nets[0] if env.board.turn == chess.WHITE else nets[1]
             mcts = MCTS(net, num_simulations=num_simulations)
-            visit_counts = mcts.run(env.get_state())
+            visit_counts = mcts.run(env.board)
             best_move_idx = max(visit_counts, key=visit_counts.get)
-            move = list(env.legal_moves())[best_move_idx]
+            move = index_to_move(best_move_idx)
             _, reward, done = env.step(move)
             if done:
                 if reward == 1:

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,28 @@
+import torch
+
+from chess_ai.evaluation import evaluate
+from chess_ai.action_index import ACTION_SIZE
+from chess_ai.config import Config
+
+
+class DummyNet(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        batch = x.size(0)
+        log_p = torch.log_softmax(torch.ones(batch, ACTION_SIZE), dim=1)
+        v = torch.zeros(batch, 1)
+        return log_p, v
+
+
+def test_evaluate_runs():
+    net = DummyNet()
+    original_epsilon = Config.DIRICHLET_EPSILON
+    Config.DIRICHLET_EPSILON = 0.0
+    try:
+        stats = evaluate(net, net, num_games=1, num_simulations=1)
+    finally:
+        Config.DIRICHLET_EPSILON = original_epsilon
+    assert set(stats.keys()) == {"wins", "losses", "draws"}
+    assert sum(stats.values()) == 1


### PR DESCRIPTION
## Summary
- fix evaluation to pass the board state into MCTS
- use `index_to_move` for MCTS move selection
- add regression test for `evaluate`

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841503535848325945c5f102e76d9ca