### PR TITLE
Fix replay buffer imports

### DIFF
--- a/chess_ai/replay_buffer.py
+++ b/chess_ai/replay_buffer.py
@@ -1,6 +1,4 @@
-import random
 from collections import deque
-from typing import Sequence
 
 import numpy as np
 
@@ -24,7 +22,9 @@ class ReplayBuffer:
         if batch_size > len(self.buffer):
             raise ValueError("Batch size larger than buffer")
 
-        indices = np.random.choice(len(self.buffer), size=batch_size, replace=False)
+        indices = np.random.choice(
+            len(self.buffer), size=batch_size, replace=False
+        )
         indices = np.sort(indices)
         batch = [self.buffer[i] for i in indices]
         states, policies, values = zip(*batch)


### PR DESCRIPTION
## Summary
- drop unused imports in replay buffer
- wrap long `np.random.choice` call

## Testing
- `flake8 chess_ai/replay_buffer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841503672648325953ec7640bfbb0b2