### PR TITLE
Fix PEP8 in scripts

### DIFF
--- a/superengine/scripts/prepare_data.py
+++ b/superengine/scripts/prepare_data.py
@@ -1,8 +1,19 @@
 #!/usr/bin/env python3
-import chess, chess.pgn, numpy as np, sys
+
+import chess
+import chess.pgn
+import numpy as np
+import sys
+
 
 def is_quiet(board):
-    return not board.is_check() and (not board.is_capture(board.peek()) if board.move_stack else True)
+    return (
+        not board.is_check()
+        and (
+            not board.is_capture(board.peek()) if board.move_stack else True
+        )
+    )
+
 
 X, y = [], []
 for pgn in sys.argv[1:]:

--- a/superengine/scripts/selfplay_ray.py
+++ b/superengine/scripts/selfplay_ray.py
@@ -1,5 +1,13 @@
-import ray, subprocess, os, random, uuid
+import ray
+import subprocess
+import os
+import random
+import uuid
+
+
 ray.init(address="auto")
+
+
 @ray.remote
 def selfplay_game(net_path):
     seed = random.getrandbits(32)
@@ -8,8 +16,10 @@ def selfplay_game(net_path):
            "--net", net_path, "--games", "1"]
     p = subprocess.run(cmd, capture_output=True, text=True)
     os.makedirs("games", exist_ok=True)
-    with open(f"games/{game_id}.pgn", "w") as f: f.write(p.stdout)
+    with open(f"games/{game_id}.pgn", "w") as f:
+        f.write(p.stdout)
     return 1
+
 
 futures = [selfplay_game.remote("nets/tiny_v1.nnue") for _ in range(10000)]
 ray.get(futures)

--- a/superengine/scripts/train_nnue.py
+++ b/superengine/scripts/train_nnue.py
@@ -1,5 +1,8 @@
-import torch, numpy as np, lightning as L
+import torch
+import numpy as np
+import lightning as L
 from torch import nn
+
 
 class TinyNNUE(nn.Module):
     def __init__(self, inputs=768, h1=512, h2=256):
@@ -7,26 +10,41 @@ class TinyNNUE(nn.Module):
         self.l1 = nn.Linear(inputs, h1, bias=False)
         self.l2 = nn.Linear(h1, h2, bias=True)
         self.out = nn.Linear(h2, 1, bias=True)
+
     def forward(self, x):
         x = torch.relu(self.l1(x))
         x = torch.relu(self.l2(x))
         return self.out(x)
+
 
 class Module(L.LightningModule):
     def __init__(self):
         super().__init__()
         self.net = TinyNNUE()
         self.loss = nn.MSELoss()
+
     def training_step(self, batch, _):
         x, y = batch
         return self.loss(self.net(x), y)
+
     def configure_optimizers(self):
         return torch.optim.AdamW(self.parameters(), 1e-3)
+
 
 data = torch.utils.data.TensorDataset(
     torch.from_numpy(np.load("fen_vec.npy")),
     torch.from_numpy(np.load("score.npy")).unsqueeze(1))
-loader = torch.utils.data.DataLoader(data, batch_size=8192, shuffle=True, num_workers=4)
-trainer = L.Trainer(max_epochs=4, precision="bf16-mixed", devices=8, accelerator="gpu")
+loader = torch.utils.data.DataLoader(
+    data,
+    batch_size=8192,
+    shuffle=True,
+    num_workers=4,
+)
+trainer = L.Trainer(
+    max_epochs=4,
+    precision="bf16-mixed",
+    devices=8,
+    accelerator="gpu",
+)
 trainer.fit(Module(), loader)
 torch.save(trainer.model.net.state_dict(), "../nets/tiny_v1.nnue")

--- a/superengine/scripts/train_policy.py
+++ b/superengine/scripts/train_policy.py
@@ -56,7 +56,13 @@ class Module(L.LightningModule):
         loss_p = -(p_target * log_p).sum(dim=1).mean()
         loss_v = self.loss_mse(v.view(-1), v_target)
         loss = loss_p + loss_v
-        self.log_dict({"loss": loss, "policy_loss": loss_p, "value_loss": loss_v})
+        self.log_dict(
+            {
+                "loss": loss,
+                "policy_loss": loss_p,
+                "value_loss": loss_v,
+            }
+        )
         return loss
 
     def configure_optimizers(self):
@@ -66,7 +72,13 @@ class Module(L.LightningModule):
 def main():
     dataset = load_games("games")
     loader = DataLoader(dataset, batch_size=256, shuffle=True, num_workers=4)
-    trainer = L.Trainer(max_epochs=5, devices=1 if not torch.cuda.is_available() else torch.cuda.device_count(), accelerator="gpu" if torch.cuda.is_available() else "cpu")
+    trainer = L.Trainer(
+        max_epochs=5,
+        devices=(
+            1 if not torch.cuda.is_available() else torch.cuda.device_count()
+        ),
+        accelerator="gpu" if torch.cuda.is_available() else "cpu",
+    )
     trainer.fit(Module(), loader)
     os.makedirs("../nets", exist_ok=True)
     torch.save(trainer.model.net.state_dict(), "../nets/gpu_policy.onnx")


### PR DESCRIPTION
## Summary
- split combined imports across scripts
- add blank lines per PEP8
- fix inline write statements and wrap long lines
- reformat DataLoader and Trainer constructors

## Testing
- `flake8 superengine/scripts`

------
https://chatgpt.com/codex/tasks/task_e_6841503a911c8325ba201d02c1ea44c7