### PR TITLE
Add quiet move filter for self-play data

### DIFF
--- a/chess_ai/config.py
+++ b/chess_ai/config.py
@@ -20,6 +20,7 @@ class Config:
     NUM_FILTERS = 256
     LEARNING_RATE = 0.01
     BATCH_SIZE = 32
+    FILTER_QUIET_POSITIONS = True
     WEIGHT_DECAY = 1e-4
     MOMENTUM = 0.9
 

--- a/chess_ai/game_environment.py
+++ b/chess_ai/game_environment.py
@@ -37,6 +37,15 @@ class GameEnvironment:
     def undo(self):
         self.board.pop()
 
+    def is_quiet_move(self, move: chess.Move) -> bool:
+        """Return True if ``move`` is non-capturing, non-checking and current
+        player is not already in check."""
+        return (
+            not self.board.is_capture(move)
+            and not self.board.gives_check(move)
+            and not self.board.is_check()
+        )
+
     @classmethod
     def encode_board(cls, board: chess.Board):
         """Encode board into an 8x8x18 tensor of binary features."""

--- a/chess_ai/self_play.py
+++ b/chess_ai/self_play.py
@@ -21,7 +21,9 @@ def run_self_play(network, num_simulations: int = Config.NUM_SIMULATIONS):
             pi[idx] = c
         best_move_idx = max(visit_counts, key=visit_counts.get)
         move = index_to_move(best_move_idx)
-        trajectory.append((state, pi, current_player))
+        is_quiet = env.is_quiet_move(move)
+        if not Config.FILTER_QUIET_POSITIONS or is_quiet:
+            trajectory.append((state, pi, current_player))
         state, reward, done = env.step(move)
         if done:
             for s, p, player in trajectory:

--- a/tests/test_quiet_move.py
+++ b/tests/test_quiet_move.py
@@ -1,0 +1,27 @@
+import chess
+
+from chess_ai.game_environment import GameEnvironment
+
+
+def test_is_quiet_move():
+    env = GameEnvironment()
+
+    # Quiet opening move
+    move = chess.Move.from_uci("e2e4")
+    assert env.is_quiet_move(move)
+    env.step(move)
+
+    # Capture is not quiet
+    env.step(chess.Move.from_uci("d7d5"))
+    capture = chess.Move.from_uci("e4d5")
+    assert not env.is_quiet_move(capture)
+
+    # Check move (Qxf7+) is not quiet
+    env.reset()
+    env.step(chess.Move.from_uci("e2e4"))
+    env.step(chess.Move.from_uci("e7e5"))
+    env.step(chess.Move.from_uci("d1h5"))
+    env.step(chess.Move.from_uci("b8c6"))
+    check_move = chess.Move.from_uci("h5f7")
+    assert not env.is_quiet_move(check_move)
+


### PR DESCRIPTION
## Summary
- add `is_quiet_move` helper to game environment
- filter self-play data using quiet move detection
- expose `FILTER_QUIET_POSITIONS` option in config
- add tests for quiet move logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684155b9cfa08325bc95cccc4d4821a9