### PR TITLE
Improve FEN parser handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__/
 *.pyc
+
+superengine/build/
+chess_ai.egg-info/

--- a/superengine/CMakeLists.txt
+++ b/superengine/CMakeLists.txt
@@ -25,4 +25,8 @@ add_executable(test_movegen tests/test_movegen.cpp)
 target_link_libraries(test_movegen PRIVATE engine Catch2::Catch2WithMain)
 add_test(NAME test_movegen COMMAND test_movegen)
 
+add_executable(test_position tests/test_position.cpp)
+target_link_libraries(test_position PRIVATE engine Catch2::Catch2WithMain)
+add_test(NAME test_position COMMAND test_position)
+
 enable_testing()

--- a/superengine/engine/position.cpp
+++ b/superengine/engine/position.cpp
@@ -10,9 +10,26 @@ Position::Position(const std::string& fen) {
     side=WHITE;
 
     std::istringstream ss(fen);
-    std::string board, stm;
-    ss >> board >> stm;
+    std::string board, stm, castling = "-", ep = "-";
+    if (!(ss >> board >> stm))
+        return; // invalid FEN, leave empty position
+    if (!(ss >> castling)) castling = "-";
+    if (!(ss >> ep)) ep = "-";
+    if (!(ss >> halfmove_clock)) halfmove_clock = 0;
+    if (!(ss >> fullmove_number)) fullmove_number = 1;
+
     side = (stm=="w"?WHITE:BLACK);
+    castling_rights = 0;
+    if(castling.find('K') != std::string::npos) castling_rights |= 1;
+    if(castling.find('Q') != std::string::npos) castling_rights |= 2;
+    if(castling.find('k') != std::string::npos) castling_rights |= 4;
+    if(castling.find('q') != std::string::npos) castling_rights |= 8;
+    en_passant = -1;
+    if(ep != "-" && ep.size()==2){
+        int file = ep[0]-'a';
+        int rank = ep[1]-'1';
+        en_passant = rank*8 + file;
+    }
 
     int sq=56; // start at a8
     for(char ch : board){
@@ -40,4 +57,15 @@ Position::Position(const std::string& fen) {
         occupied_bb[c]=occ;
     }
     all_occupied = occupied_bb[WHITE]|occupied_bb[BLACK];
+}
+
+Piece Position::piece_on(int sq) const {
+    Bitboard mask = 1ULL<<sq;
+    for(int c=0;c<2;++c){
+        for(int p=0;p<PIECE_NB;++p){
+            if(piece_bb[c][p] & mask)
+                return static_cast<Piece>(p);
+        }
+    }
+    return PIECE_NB; // invalid
 }

--- a/superengine/engine/position.h
+++ b/superengine/engine/position.h
@@ -10,6 +10,10 @@ struct Position {
     Bitboard occupied_bb[2]{};
     Bitboard all_occupied{};
     Color side{};
+    uint8_t castling_rights{}; // bit0=K, bit1=Q, bit2=k, bit3=q
+    int8_t en_passant{-1};    // -1 if none
+    int halfmove_clock{};
+    int fullmove_number{1};
 
     Position() = default;
     explicit Position(const std::string& fen);
@@ -17,4 +21,5 @@ struct Position {
     Bitboard pieces(Piece pc, Color c) const { return piece_bb[c][pc]; }
     Bitboard occupied() const { return all_occupied; }
     Color side_to_move() const { return side; }
+    Piece piece_on(int sq) const;
 };

--- a/superengine/tests/test_position.cpp
+++ b/superengine/tests/test_position.cpp
@@ -1,0 +1,21 @@
+#include <catch2/catch_test_macros.hpp>
+#include "position.h"
+
+TEST_CASE("Fen parsing extras", "[position]") {
+    Position pos("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    REQUIRE(pos.side_to_move() == WHITE);
+    REQUIRE(pos.castling_rights == 0b1111);
+    REQUIRE(pos.en_passant == -1);
+    REQUIRE(pos.halfmove_clock == 0);
+    REQUIRE(pos.fullmove_number == 1);
+    // check piece on e1 is king
+    REQUIRE(pos.piece_on(4) == KING);
+}
+
+TEST_CASE("Fen with en passant target", "[position]") {
+    Position pos("rnbqkbnr/pppppppp/8/8/8/4P3/PPPP1PPP/RNBQKBNR b KQkq e3 0 1");
+    REQUIRE(pos.en_passant == 20); // e3 square index
+    REQUIRE(pos.side_to_move() == BLACK);
+    REQUIRE(pos.castling_rights == 0b1111);
+    REQUIRE(pos.piece_on(20) == PAWN); // white pawn on e3
+}


### PR DESCRIPTION
## Summary
- make FEN parser more robust with default fields
- add regression test covering en passant parsing

## Testing
- `pytest -q`
- `cmake .. && cmake --build . && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6841746fb5588325ad63ad2efd97d002