### PR TITLE
Improve README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,17 @@ demonstrieren.
 ## Installation
 
 ```bash
-pip install -r requirements.txt
+./scripts/install.sh
 ```
 
-Optional kann die C++-Engine in `superengine/` separat mit CMake gebaut werden.
+Dies installiert alle Python-Abhängigkeiten und baut standardmäßig auch die C++
+Engine in `superengine/`.
+Wer nur die Python-Funktionalität benötigt, kann stattdessen einfach
+
+```bash
+pip install -r requirements.txt
+```
+ausführen und den Engine-Build überspringen.
 
 ## Verwendung
 
@@ -37,6 +44,15 @@ Kurzes Selbstspiel und Evaluierung:
 ```bash
 python -m chess_ai.self_play
 python -m chess_ai.evaluation
+```
+
+Beispielausgabe von `python -m chess_ai.self_play`:
+
+```text
+Step 0: value=0.00
+Step 1: value=-0.00
+Step 2: value=0.00
+Self-play finished successfully.
 ```
 
 Alle Parameter befinden sich in `chess_ai/config.py`. Das Flag

--- a/chess_ai/self_play.py
+++ b/chess_ai/self_play.py
@@ -31,3 +31,22 @@ def run_self_play(network, num_simulations: int = Config.NUM_SIMULATIONS):
                 yield s, p, z
             break
         current_player *= -1
+
+
+if __name__ == "__main__":
+    """Run a short self-play demo when executed as a script."""
+    from .policy_value_net import PolicyValueNet
+
+    net = PolicyValueNet(
+        GameEnvironment.NUM_CHANNELS,
+        ACTION_SIZE,
+        num_blocks=1,
+        filters=32,
+    )
+
+    for i, (_, _, value) in enumerate(run_self_play(net, num_simulations=1)):
+        print(f"Step {i}: value={value:.2f}")
+        if i >= 2:
+            break
+
+    print("Self-play finished successfully.")


### PR DESCRIPTION
## Summary
- document `./scripts/install.sh` as the recommended install method
- note how to skip building the C++ engine
- show example console output from running `python -m chess_ai.self_play`
- add a small self-play demo when running the module directly

## Testing
- `pip install -e .`
- `pytest -q`
- `python -m chess_ai.self_play | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_684291f4206c8325a5f4258189ce2cc2