### PR TITLE
Unify move generation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Repository verfolgen kannst.
 - [ ] `Position::in_check(Color)` komplettieren
 - [ ] En‑Passant‑Logik ergänzen
 - [ ] King‑Moves und Rochade umsetzen
-- [ ] `generate_all_pseudo` und `generate_legal_moves` vereinen
+- [x] `generate_all_pseudo` und `generate_legal_moves` vereinen -> `generate_moves`
 
 #### 1.2 Suchkern (Alpha‑Beta, Quiescence, TT, LMR, Null‑Move)
 

--- a/superengine/engine/movegen.cpp
+++ b/superengine/engine/movegen.cpp
@@ -239,7 +239,7 @@ void generate_king_moves(const Position& pos, MoveList& out){
     }
 }
 
-MoveList generate_pseudo_legal(const Position& pos){
+MoveList generate_pseudo_moves(const Position& pos){
     MoveList ml; ml.reserve(64);
     generate_pawn_moves(pos, ml);
     generate_knight_moves(pos, ml);
@@ -248,9 +248,9 @@ MoveList generate_pseudo_legal(const Position& pos){
     return ml;
 }
 
-MoveList generate_legal_moves(const Position& pos){
+MoveList generate_moves(const Position& pos){
     MoveList ml;
-    auto pseudo = generate_pseudo_legal(pos);
+    auto pseudo = generate_pseudo_moves(pos);
     for(const auto& m: pseudo){
         Position next = pos;
         next.do_move(m);

--- a/superengine/engine/movegen.h
+++ b/superengine/engine/movegen.h
@@ -21,8 +21,8 @@ void generate_knight_moves(const Position& pos, MoveList& out);
 void generate_sliding_moves(const Position& pos, MoveList& out);
 void generate_king_moves(const Position& pos, MoveList& out);
 
-MoveList generate_pseudo_legal(const Position& pos);
-MoveList generate_legal_moves(const Position& pos);
+// unified move generator returning only legal moves
+MoveList generate_moves(const Position& pos);
 
 inline MoveList generate_pawn_knight(const Position& pos) {
     MoveList ml; ml.reserve(32);

--- a/superengine/engine/position.cpp
+++ b/superengine/engine/position.cpp
@@ -1,5 +1,7 @@
 #include "position.h"
 #include "movegen.h"
+
+namespace movegen { MoveList generate_pseudo_moves(const Position& pos); }
 #include <sstream>
 #include <cctype>
 
@@ -79,7 +81,7 @@ bool Position::in_check(Color c) const {
     Color opp = c==WHITE?BLACK:WHITE;
     Position tmp = *const_cast<Position*>(this);
     tmp.side = opp;
-    movegen::MoveList moves = movegen::generate_pseudo_legal(tmp);
+    movegen::MoveList moves = movegen::generate_pseudo_moves(tmp);
     for(const auto& m: moves){
         if(m.to == king_sq) return true;
     }

--- a/superengine/engine/search.cpp
+++ b/superengine/engine/search.cpp
@@ -19,7 +19,7 @@ int Search::pv_node(Position& pos, int alpha, int beta, int depth) {
     int eval = nnue::eval(pos);
     if (eval >= beta) return eval;
 
-    auto moves = movegen::generate_pseudo_legal(pos);
+    auto moves = movegen::generate_moves(pos);
     for (size_t i = 0; i < moves.size(); ++i) {
         Position next = pos;
         next.do_move(moves[i]);
@@ -39,7 +39,7 @@ int Search::quiesce(Position& pos, int alpha, int beta){
     if(stand_pat >= beta) return beta;
     if(stand_pat > alpha) alpha = stand_pat;
 
-    auto moves = movegen::generate_pseudo_legal(pos);
+    auto moves = movegen::generate_moves(pos);
     for(const auto& m: moves){
         Piece capture = pos.piece_on(m.to);
         if(capture == PIECE_NB) continue; // only captures

--- a/superengine/tests/test_movegen.cpp
+++ b/superengine/tests/test_movegen.cpp
@@ -21,3 +21,9 @@ TEST_CASE("Knight on d4", "[movegen]") {
     auto moves = movegen::generate_pawn_knight(pos);
     REQUIRE(moves.size() == 8);
 }
+
+TEST_CASE("Start position legal move count", "[movegen]") {
+    Position pos("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    auto moves = movegen::generate_moves(pos);
+    REQUIRE(moves.size() == 20);
+}


### PR DESCRIPTION
## Summary
- replace `generate_pseudo_legal` and `generate_legal_moves` with `generate_moves`
- adjust search and position code to use the new API
- add a unit test for the start position move count
- note completion of the TODO item in README

## Testing
- `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build`
- `ctest --test-dir build`
- `pytest -q` *(fails: ModuleNotFoundError: numpy/torch/chess)*

------
https://chatgpt.com/codex/tasks/task_e_684291f16400832586790dd5ca105fdd