### PR TITLE
Add en passant support

### DIFF
--- a/superengine/engine/movegen.cpp
+++ b/superengine/engine/movegen.cpp
@@ -58,8 +58,13 @@ void generate_pawn_moves(const Position& pos, MoveList& out){
         out.push_back({from,to,0});
     }
     // captures left/right
-    Bitboard left = ((wp & ~bb::FILE_A)<<7) & occB;
-    Bitboard right = ((wp & ~bb::FILE_H)<<9) & occB;
+    Bitboard left_diag = (wp & ~bb::FILE_A) << 7;
+    Bitboard right_diag = (wp & ~bb::FILE_H) << 9;
+    Bitboard left = left_diag & occB;
+    Bitboard right = right_diag & occB;
+    Bitboard ep_target = pos.en_passant==-1 ? 0ULL : (1ULL << pos.en_passant);
+    Bitboard ep_left = left_diag & ep_target;
+    Bitboard ep_right = right_diag & ep_target;
     Bitboard promo_left = left & promo_rank;
     Bitboard normal_left = left & ~promo_rank;
     while(normal_left){
@@ -83,6 +88,16 @@ void generate_pawn_moves(const Position& pos, MoveList& out){
         int to = bb::pop_lsb(promo_right);
         int from = to-9;
         for(int p=1;p<=4;++p) out.push_back({from,to,p});
+    }
+    while(ep_left){
+        int to = bb::pop_lsb(ep_left);
+        int from = to-7;
+        out.push_back({from,to,0});
+    }
+    while(ep_right){
+        int to = bb::pop_lsb(ep_right);
+        int from = to-9;
+        out.push_back({from,to,0});
     }
     }
 
@@ -110,8 +125,13 @@ void generate_pawn_moves(const Position& pos, MoveList& out){
         int from=to+16;
         out.push_back({from,to,0});
     }
-    Bitboard leftB = ((bp & ~bb::FILE_H)>>9) & occW;
-    Bitboard rightB = ((bp & ~bb::FILE_A)>>7) & occW;
+    Bitboard left_diagB = (bp & ~bb::FILE_H) >> 9;
+    Bitboard right_diagB = (bp & ~bb::FILE_A) >> 7;
+    Bitboard leftB = left_diagB & occW;
+    Bitboard rightB = right_diagB & occW;
+    Bitboard ep_targetB = pos.en_passant==-1 ? 0ULL : (1ULL << pos.en_passant);
+    Bitboard ep_leftB = left_diagB & ep_targetB;
+    Bitboard ep_rightB = right_diagB & ep_targetB;
     Bitboard promo_leftB = leftB & promo_rankB;
     Bitboard normal_leftB = leftB & ~promo_rankB;
     while(normal_leftB){
@@ -124,6 +144,11 @@ void generate_pawn_moves(const Position& pos, MoveList& out){
         int from=to+9;
         for(int p=1;p<=4;++p) out.push_back({from,to,p});
     }
+    while(ep_leftB){
+        int to = bb::pop_lsb(ep_leftB);
+        int from = to+9;
+        out.push_back({from,to,0});
+    }
     Bitboard promo_rightB = rightB & promo_rankB;
     Bitboard normal_rightB = rightB & ~promo_rankB;
     while(normal_rightB){
@@ -135,6 +160,11 @@ void generate_pawn_moves(const Position& pos, MoveList& out){
         int to=bb::pop_lsb(promo_rightB);
         int from=to+7;
         for(int p=1;p<=4;++p) out.push_back({from,to,p});
+    }
+    while(ep_rightB){
+        int to = bb::pop_lsb(ep_rightB);
+        int from = to+7;
+        out.push_back({from,to,0});
     }
     }
 }

--- a/superengine/engine/position.cpp
+++ b/superengine/engine/position.cpp
@@ -92,6 +92,11 @@ void Position::do_move(const movegen::Move& m){
     Color opp = c==WHITE?BLACK:WHITE;
     Bitboard from_mask = 1ULL<<m.from;
     Bitboard to_mask   = 1ULL<<m.to;
+    // handle en-passant capture
+    if(pc == PAWN && m.to == en_passant && en_passant != -1){
+        Bitboard cap_mask = c==WHITE ? (to_mask>>8) : (to_mask<<8);
+        for(int p=0;p<PIECE_NB;++p) piece_bb[opp][p] &= ~cap_mask;
+    }
     for(int p=0;p<PIECE_NB;++p) {
         piece_bb[c][p] &= ~from_mask;
         piece_bb[c][p] &= ~to_mask;
@@ -102,6 +107,13 @@ void Position::do_move(const movegen::Move& m){
     {
         piece_bb[c][pc] &= ~to_mask;
         piece_bb[c][m.promo] |= to_mask;
+    }
+    en_passant = -1;
+    if(pc==PAWN){
+        if(c==WHITE && m.from/8==1 && m.to/8==3)
+            en_passant = m.from + 8;
+        else if(c==BLACK && m.from/8==6 && m.to/8==4)
+            en_passant = m.from - 8;
     }
     // recompute occupancy
     for(int col=0;col<2;++col){

--- a/superengine/tests/test_movegen.cpp
+++ b/superengine/tests/test_movegen.cpp
@@ -21,3 +21,13 @@ TEST_CASE("Knight on d4", "[movegen]") {
     auto moves = movegen::generate_pawn_knight(pos);
     REQUIRE(moves.size() == 8);
 }
+
+TEST_CASE("En passant generation", "[movegen]") {
+    Position pos("rnbqkb1r/ppp1pppp/5n2/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3");
+    auto moves = movegen::generate_pseudo_legal(pos);
+    bool found = false;
+    for(const auto& m : moves)
+        if(m.from == 36 && m.to == 43)
+            found = true;
+    REQUIRE(found);
+}


### PR DESCRIPTION
## Summary
- support en-passant captures in pawn move generation
- handle en-passant in `Position::do_move`
- unit test for en-passant move generation

## Testing
- `cmake -S superengine -B superengine/build`
- `cmake --build superengine/build`
- `ctest --test-dir superengine/build`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684291efe1e48325aa0155b8838486df