### PR TITLE
Add advanced search features and tests

### DIFF
--- a/superengine/CMakeLists.txt
+++ b/superengine/CMakeLists.txt
@@ -16,7 +16,9 @@ find_package(Threads REQUIRED)
 add_library(engine
     engine/bitboard.cpp
     engine/movegen.cpp
-    engine/position.cpp)
+    engine/position.cpp
+    engine/nnue_eval.cpp
+    engine/search.cpp)
 
 target_include_directories(engine PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/engine)
 target_link_libraries(engine PUBLIC Threads::Threads)
@@ -28,5 +30,13 @@ add_test(NAME test_movegen COMMAND test_movegen)
 add_executable(test_position tests/test_position.cpp)
 target_link_libraries(test_position PRIVATE engine Catch2::Catch2WithMain)
 add_test(NAME test_position COMMAND test_position)
+
+add_executable(test_perft tests/perft.cpp)
+target_link_libraries(test_perft PRIVATE engine Catch2::Catch2WithMain)
+add_test(NAME test_perft COMMAND test_perft)
+
+add_executable(test_search tests/test_search.cpp)
+target_link_libraries(test_search PRIVATE engine Catch2::Catch2WithMain)
+add_test(NAME test_search COMMAND test_search)
 
 enable_testing()

--- a/superengine/engine/nnue_eval.cpp
+++ b/superengine/engine/nnue_eval.cpp
@@ -6,13 +6,7 @@ nnue::Network nnue::net;
 
 static int16_t clamp_relu(int32_t x) { return x > 0 ? (x < 32767 ? x : 32767) : 0; }
 
-int nnue::eval(const Position& pos) {
-    alignas(32) int16_t feat[INPUTS];
-    extract_features(pos, feat); // to be implemented
-    alignas(32) int16_t hidden1[HIDDEN1];
-    for (int i=0;i<HIDDEN1;i+=16) {
-        // placeholder loop
-    }
+int nnue::eval(const Position&) {
     return 0;
 }
 

--- a/superengine/engine/search.cpp
+++ b/superengine/engine/search.cpp
@@ -7,34 +7,75 @@ int Search::search(Position& pos, int depth){
     return pv_node(pos, -INF, INF, depth);
 }
 
+int Search::search(Position& pos, const Limits& limits){
+    limits_ = limits;
+    nodes_ = 0;
+    start_ = std::chrono::steady_clock::now();
+    int best = 0;
+    for(int d=1;;++d){
+        int score = pv_node(pos, -INF, INF, d);
+        if(!stop()) best = score;
+        if(stop()) break;
+        if(limits.nodes==0 && limits.time_ms==0) break; // fallback
+    }
+    return best;
+}
+
 int Search::pv_node(Position& pos, int alpha, int beta, int depth) {
+    ++nodes_;
+    if (stop()) return nnue::eval(pos);
+
     auto key = pos.to_fen();
     auto it = tt.find(key);
     if(it != tt.end() && it->second.depth >= depth)
         return it->second.score;
 
+    auto moves = movegen::generate_legal_moves(pos);
+    if(moves.empty())
+        return pos.in_check(pos.side) ? -INF + depth : 0;
+
     if (depth <= 0)
         return quiesce(pos, alpha, beta);
+
+    if(depth >= 3 && !pos.in_check(pos.side)){
+        Position null = pos;
+        null.side = pos.side==WHITE?BLACK:WHITE;
+        null.en_passant = -1;
+        int score = -pv_node(null, -beta, -beta+1, depth-3);
+        if(score >= beta){
+            store_tt(key,{depth,score});
+            return score;
+        }
+    }
 
     int eval = nnue::eval(pos);
     if (eval >= beta) return eval;
 
-    auto moves = movegen::generate_pseudo_legal(pos);
     for (size_t i = 0; i < moves.size(); ++i) {
         Position next = pos;
         next.do_move(moves[i]);
-        int score = -pv_node(next, -beta, -alpha, depth - 1);
+        int score;
+        if(i >= 3 && depth >= 3){
+            score = -pv_node(next, -alpha-1, -alpha, depth-2);
+            if(score > alpha)
+                score = -pv_node(next, -beta, -alpha, depth-1);
+        }else{
+            score = -pv_node(next, -beta, -alpha, depth-1);
+        }
         if (score >= beta) {
-            tt[key] = {depth, score};
+            store_tt(key, {depth, score});
             return score;
         }
         if (score > alpha) alpha = score;
     }
-    tt[key] = {depth, alpha};
+    store_tt(key, {depth, alpha});
     return alpha;
 }
 
 int Search::quiesce(Position& pos, int alpha, int beta){
+    ++nodes_;
+    if(stop()) return nnue::eval(pos);
+
     int stand_pat = nnue::eval(pos);
     if(stand_pat >= beta) return beta;
     if(stand_pat > alpha) alpha = stand_pat;
@@ -45,9 +86,31 @@ int Search::quiesce(Position& pos, int alpha, int beta){
         if(capture == PIECE_NB) continue; // only captures
         Position next = pos;
         next.do_move(m);
+        if(next.in_check(pos.side)) continue;
         int score = -quiesce(next, -beta, -alpha);
         if(score >= beta) return score;
         if(score > alpha) alpha = score;
     }
     return alpha;
+}
+
+bool Search::stop() const {
+    if(limits_.nodes && nodes_ >= limits_.nodes) return true;
+    if(limits_.time_ms){
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now()-start_).count();
+        if(elapsed >= limits_.time_ms) return true;
+    }
+    return false;
+}
+
+void Search::store_tt(const std::string& key, TTEntry entry){
+    auto it = tt.find(key);
+    if(it == tt.end()){
+        if(tt.size() >= TT_MAX)
+            tt.erase(tt.begin());
+        tt.emplace(key, entry);
+    }else if(entry.depth >= it->second.depth){
+        it->second = entry;
+    }
 }

--- a/superengine/engine/search.h
+++ b/superengine/engine/search.h
@@ -3,14 +3,30 @@
 #include "movegen.h"
 
 #include <unordered_map>
+#include <chrono>
+#include <cstddef>
 
 struct TTEntry { int depth; int score; };
+
+struct Limits {
+    int time_ms{0};
+    std::size_t nodes{0};
+};
 
 class Search {
 public:
     int search(Position& pos, int depth);
+    int search(Position& pos, const Limits& limits);
+
 private:
     int pv_node(Position& pos, int alpha, int beta, int depth);
     int quiesce(Position& pos, int alpha, int beta);
+    bool stop() const;
+    void store_tt(const std::string& key, TTEntry entry);
+
     std::unordered_map<std::string, TTEntry> tt;
+    Limits limits_{};
+    std::size_t nodes_{0};
+    std::chrono::steady_clock::time_point start_{};
+    static constexpr std::size_t TT_MAX = 100000;
 };

--- a/superengine/tests/perft.cpp
+++ b/superengine/tests/perft.cpp
@@ -1,1 +1,26 @@
-// placeholder perft test
+#include <catch2/catch_test_macros.hpp>
+#include "position.h"
+#include "movegen.h"
+
+using namespace movegen;
+
+static uint64_t perft(Position& pos, int depth){
+    if(depth==0) return 1;
+    auto moves = generate_pseudo_legal(pos);
+    uint64_t nodes = 0;
+    for(const auto& m : moves){
+        Position next = pos;
+        next.do_move(m);
+        nodes += perft(next, depth-1);
+    }
+    return nodes;
+}
+
+TEST_CASE("Perft startpos", "[perft]"){
+    init_attack_tables();
+    Position pos("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    REQUIRE(perft(pos,1) == 20);
+    REQUIRE(perft(pos,2) == 400);
+    REQUIRE(perft(pos,3) == 8902);
+}
+

--- a/superengine/tests/test_search.cpp
+++ b/superengine/tests/test_search.cpp
@@ -1,0 +1,14 @@
+#include <catch2/catch_test_macros.hpp>
+#include "position.h"
+#include "movegen.h"
+#include "search.h"
+
+TEST_CASE("Mate in one", "[search]"){
+    movegen::init_attack_tables();
+    Position pos("7k/6Q1/7K/8/8/8/8/8 w - - 0 1");
+    Search s;
+    Limits lim; lim.nodes = 10000; // sufficient
+    int score = s.search(pos, lim);
+    REQUIRE(score > 30000);
+}
+


### PR DESCRIPTION
## Summary
- extend search with time/node-limited iterative deepening
- add null-move pruning and late move reductions
- limit transposition table size
- include search files in build and add perft/mate tests

## Testing
- `cmake -B build -S superengine`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684291f2cae8832587000168f3b9d052