### PR TITLE
Fix movegen test

### DIFF
--- a/superengine/engine/movegen.h
+++ b/superengine/engine/movegen.h
@@ -21,6 +21,14 @@ void generate_knight_moves(const Position& pos, MoveList& out);
 void generate_sliding_moves(const Position& pos, MoveList& out);
 void generate_king_moves(const Position& pos, MoveList& out);
 
+// generate all pseudo legal moves without checking king safety
+MoveList generate_pseudo_moves(const Position& pos);
+
+// temporary alias for backwards compatibility
+inline MoveList generate_pseudo_legal(const Position& pos) {
+    return generate_pseudo_moves(pos);
+}
+
 // unified move generator returning only legal moves
 MoveList generate_moves(const Position& pos);
 

--- a/superengine/tests/test_movegen.cpp
+++ b/superengine/tests/test_movegen.cpp
@@ -22,19 +22,18 @@ TEST_CASE("Knight on d4", "[movegen]") {
     REQUIRE(moves.size() == 8);
 }
 
-codex/implement-en-passant-move-generation
 TEST_CASE("En passant generation", "[movegen]") {
     Position pos("rnbqkb1r/ppp1pppp/5n2/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3");
-    auto moves = movegen::generate_pseudo_legal(pos);
+    auto moves = movegen::generate_pseudo_moves(pos);
     bool found = false;
     for(const auto& m : moves)
         if(m.from == 36 && m.to == 43)
             found = true;
     REQUIRE(found);
+}
 
 TEST_CASE("Start position legal move count", "[movegen]") {
     Position pos("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
     auto moves = movegen::generate_moves(pos);
     REQUIRE(moves.size() == 20);
-main
 }


### PR DESCRIPTION
## Summary
- clean up `test_movegen.cpp` and close braces
- add alias for `generate_pseudo_legal`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6842982782e483258e296e71e1b434b2