### PR TITLE
Implement missing engine code

### DIFF
--- a/superengine/engine/bitboard.cpp
+++ b/superengine/engine/bitboard.cpp
@@ -1,1 +1,15 @@
+#include "bitboard.h"
 
+namespace bb {
+
+Bitboard north_one(Bitboard b) { return b << 8; }
+Bitboard south_one(Bitboard b) { return b >> 8; }
+Bitboard east_one(Bitboard b) { return (b & ~FILE_H) << 1; }
+Bitboard west_one(Bitboard b) { return (b & ~FILE_A) >> 1; }
+
+Bitboard north_east(Bitboard b) { return (b & ~FILE_H) << 9; }
+Bitboard north_west(Bitboard b) { return (b & ~FILE_A) << 7; }
+Bitboard south_east(Bitboard b) { return (b & ~FILE_H) >> 7; }
+Bitboard south_west(Bitboard b) { return (b & ~FILE_A) >> 9; }
+
+}

--- a/superengine/engine/bitboard.h
+++ b/superengine/engine/bitboard.h
@@ -15,4 +15,14 @@ namespace bb {
         b &= b - 1;
         return idx;
     }
+
+    Bitboard north_one(Bitboard b);
+    Bitboard south_one(Bitboard b);
+    Bitboard east_one(Bitboard b);
+    Bitboard west_one(Bitboard b);
+
+    Bitboard north_east(Bitboard b);
+    Bitboard north_west(Bitboard b);
+    Bitboard south_east(Bitboard b);
+    Bitboard south_west(Bitboard b);
 }

--- a/superengine/engine/nnue_eval.cpp
+++ b/superengine/engine/nnue_eval.cpp
@@ -6,8 +6,17 @@ nnue::Network nnue::net;
 
 static int16_t clamp_relu(int32_t x) { return x > 0 ? (x < 32767 ? x : 32767) : 0; }
 
-int nnue::eval(const Position&) {
-    return 0;
+int nnue::eval(const Position& pos) {
+    static const int piece_values[] = {100, 320, 330, 500, 900, 0};
+    int score = 0;
+    for(int c = 0; c < 2; ++c){
+        for(int p = 0; p < PIECE_NB; ++p){
+            Bitboard bb = pos.piece_bb[c][p];
+            int pc = __builtin_popcountll(bb) * piece_values[p];
+            score += (c == WHITE ? pc : -pc);
+        }
+    }
+    return score;
 }
 
 void nnue::load_network(const std::string& path) {

--- a/superengine/engine/search.cpp
+++ b/superengine/engine/search.cpp
@@ -51,10 +51,7 @@ int Search::pv_node(Position& pos, int alpha, int beta, int depth) {
     int eval = nnue::eval(pos);
     if (eval >= beta) return eval;
 
-codex/enhance-search-with-pruning-and-tests
-
     auto moves = movegen::generate_moves(pos);
-main
     for (size_t i = 0; i < moves.size(); ++i) {
         Position next = pos;
         next.do_move(moves[i]);

--- a/superengine/engine/uci.cpp
+++ b/superengine/engine/uci.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
+#include <sstream>
 #include "search.h"
+#include "movegen.h"
 
 void uci_loop() {
     std::string cmd;
@@ -11,10 +13,54 @@ void uci_loop() {
         } else if (cmd == "isready") {
             std::cout << "readyok\n";
         } else if (cmd.rfind("position",0)==0) {
-            // parse FEN
+            auto rest = cmd.substr(8); // skip "position"
+            std::istringstream ss(rest);
+            std::string token;
+            ss >> token;
+            if(token == "startpos"){
+                pos = Position("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+                if(ss >> token && token == "moves"){
+                    while(ss >> token){
+                        movegen::Move m;
+                        m.from = (token[0]-'a') + (token[1]-'1')*8;
+                        m.to   = (token[2]-'a') + (token[3]-'1')*8;
+                        m.promo = 0;
+                        if(token.size()==5){
+                            switch(token[4]){case 'q':m.promo=QUEEN;break;case 'r':m.promo=ROOK;break;case 'b':m.promo=BISHOP;break;case 'n':m.promo=KNIGHT;break;}
+                        }
+                        pos.do_move(m);
+                    }
+                }
+            } else if(token == "fen") {
+                std::string fen;
+                std::getline(ss, fen);
+                fen.erase(0, fen.find_first_not_of(' '));
+                pos = Position(fen);
+            }
         } else if (cmd.rfind("go",0)==0) {
-            int score = search.pv_node(pos, -32000, 32000, 3);
-            std::cout << "bestmove 0000\n";
+            auto moves = movegen::generate_moves(pos);
+            movegen::Move best{};
+            int bestScore = -32000;
+            for(const auto& m : moves){
+                Position next = pos;
+                next.do_move(m);
+                int score = -search.search(next, 3);
+                if(score > bestScore){
+                    bestScore = score;
+                    best = m;
+                }
+            }
+            char promoChar = 0;
+            if(best.promo){
+                promoChar = " nbrq"[best.promo];
+            }
+            std::string uci;
+            uci += char('a' + best.from % 8);
+            uci += char('1' + best.from / 8);
+            uci += char('a' + best.to % 8);
+            uci += char('1' + best.to / 8);
+            if(promoChar) uci += promoChar;
+            std::cout << "bestmove " << uci << "\n";
         } else if (cmd == "quit") {
             break;
         }


### PR DESCRIPTION
## Summary
- implement basic bitboard helpers
- add material evaluation in nnue_eval
- clean up search loop and provide legal move search
- expand UCI loop with FEN parsing and move selection

## Testing
- `pip install numpy torch python-chess`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456af275ec8325a51f46e2f7c6a20e