### PR TITLE
Add LMDB buffer and update roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Die Tests prüfen das Board-Encoding, MCTS, Replay Buffer und das Verhalten von
 * Gradienten-Clipping im Trainer
 * Temperaturgesteuerte Zugauswahl beim Selbstspiel
 * Helfer zum Laden von Checkpoints im NetworkManager
+* LMDB-basierter ReplayBuffer f\xC3\xBCr gro\xC3\x9Fe Datens\xC3\xA4tze
 
 ## Hintergrund und Ausblick
 
@@ -103,19 +104,19 @@ Repository verfolgen kannst.
 
 #### 1.1 Move‑Generation & Legalität
 
-- [ ] Sliding‑Moves (Bishop, Rook, Queen) implementieren
-- [ ] `Position::in_check(Color)` komplettieren
-- [ ] En‑Passant‑Logik ergänzen
-- [ ] King‑Moves und Rochade umsetzen
+- [x] Sliding‑Moves (Bishop, Rook, Queen) implementieren
+- [x] `Position::in_check(Color)` komplettieren
+- [x] En‑Passant‑Logik ergänzen
+- [x] King‑Moves und Rochade umsetzen
 - [x] `generate_all_pseudo` und `generate_legal_moves` vereinen -> `generate_moves`
 
 #### 1.2 Suchkern (Alpha‑Beta, Quiescence, TT, LMR, Null‑Move)
 
-- [ ] Transposition Table implementieren
-- [ ] Quiescence Search einbauen
-- [ ] Negamax/PVS mit LMR und Null‑Move
-- [ ] Search‑Entrypoint samt Zeitmanagement
-- [ ] Unit‑Tests (Perft, Mate‑in‑1)
+- [x] Transposition Table implementieren
+- [x] Quiescence Search einbauen
+- [x] Negamax/PVS mit LMR und Null‑Move
+- [x] Search‑Entrypoint samt Zeitmanagement
+- [x] Unit‑Tests (Perft, Mate‑in‑1)
 
 #### 1.3 NNUE‑Integration
 
@@ -126,14 +127,14 @@ Repository verfolgen kannst.
 
 #### 1.4 Tests & CI
 
-- [ ] Perft‑Tests (Depth 1–5)
+- [x] Perft‑Tests (Depth 1–5)
 - [ ] clang‑format & Sanitizer in der CI
 - [ ] Coverage‑Reporting (optional)
 
 ### 2. Python‑Komponente (chess_ai)
 
 - [ ] TensorBoard/W&B Logging integrieren
-- [ ] LMDB‑ReplayBuffer für große Datensätze
+- [x] LMDB‑ReplayBuffer für große Datensätze
 - [ ] Linting (flake8/black/isort) in der CI
 
 ### 3. CI/CD & Deployment

--- a/chess_ai/__init__.py
+++ b/chess_ai/__init__.py
@@ -4,5 +4,6 @@ from .game_environment import GameEnvironment
 from .policy_value_net import PolicyValueNet
 from .mcts import MCTS
 from .replay_buffer import ReplayBuffer
+from .lmdb_replay_buffer import LMDBReplayBuffer
 from .trainer import Trainer
 from .config import Config

--- a/chess_ai/lmdb_replay_buffer.py
+++ b/chess_ai/lmdb_replay_buffer.py
@@ -1,0 +1,83 @@
+import os
+import pickle
+
+import lmdb
+import numpy as np
+
+from .config import Config
+
+
+class LMDBReplayBuffer:
+    """Replay buffer backed by LMDB for large datasets."""
+
+    META_NEXT = b"next"
+    META_SIZE = b"size"
+
+    def __init__(self, path: str, capacity: int = Config.REPLAY_BUFFER_SIZE, map_size: int = 1 << 30):
+        self.env = lmdb.open(os.path.expanduser(path), map_size=map_size)
+        self.capacity = capacity
+        with self.env.begin(write=True) as txn:
+            if txn.get(self.META_NEXT) is None:
+                txn.put(self.META_NEXT, b"0")
+                txn.put(self.META_SIZE, b"0")
+
+    def _meta(self, key: bytes) -> int:
+        with self.env.begin() as txn:
+            val = txn.get(key)
+            return int(val.decode()) if val is not None else 0
+
+    def _set_meta(self, key: bytes, value: int):
+        with self.env.begin(write=True) as txn:
+            txn.put(key, str(value).encode())
+
+    def add(self, state, policy, value, priority: float | None = None):
+        if priority is None:
+            priority = abs(value) + 1e-5
+        next_idx = self._meta(self.META_NEXT)
+        size = self._meta(self.META_SIZE)
+        with self.env.begin(write=True) as txn:
+            txn.put(f"d{next_idx}".encode(), pickle.dumps((state, policy, value)))
+            txn.put(f"p{next_idx}".encode(), pickle.dumps(priority))
+            next_idx = (next_idx + 1) % self.capacity
+            size = min(size + 1, self.capacity)
+            txn.put(self.META_NEXT, str(next_idx).encode())
+            txn.put(self.META_SIZE, str(size).encode())
+
+    def __len__(self) -> int:
+        return self._meta(self.META_SIZE)
+
+    def _get_priorities(self, size):
+        priorities = np.empty(size, dtype=np.float32)
+        with self.env.begin() as txn:
+            for i in range(size):
+                data = txn.get(f"p{i}".encode())
+                if data is None:
+                    priorities[i] = 1e-5
+                else:
+                    priorities[i] = pickle.loads(data)
+        return priorities
+
+    def _load_batch(self, indices):
+        with self.env.begin() as txn:
+            batch = [pickle.loads(txn.get(f"d{i}".encode())) for i in indices]
+        states, policies, values = zip(*batch)
+        return states, policies, values
+
+    def sample(self, batch_size):
+        size = len(self)
+        if batch_size > size:
+            raise ValueError("Batch size larger than buffer")
+        indices = np.random.choice(size, size=batch_size, replace=False)
+        indices = np.sort(indices)
+        return self._load_batch(indices)
+
+    def sample_prioritized(self, batch_size, alpha: float = 0.6):
+        size = len(self)
+        if batch_size > size:
+            raise ValueError("Batch size larger than buffer")
+        priorities = self._get_priorities(size)
+        probs = priorities ** alpha
+        probs /= probs.sum()
+        indices = np.random.choice(size, size=batch_size, p=probs)
+        indices = np.sort(indices)
+        return self._load_batch(indices)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "torch",
     "python-chess",
     "numpy",
+    "lmdb",
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 torch
 python-chess
 numpy
+lmdb

--- a/tests/test_lmdb_replay_buffer.py
+++ b/tests/test_lmdb_replay_buffer.py
@@ -1,0 +1,30 @@
+import os
+import tempfile
+
+import numpy as np
+
+from chess_ai.lmdb_replay_buffer import LMDBReplayBuffer
+
+
+def test_lmdb_replay_buffer_add_and_sample(tmp_path):
+    path = tmp_path / "buffer.lmdb"
+    buf = LMDBReplayBuffer(str(path), capacity=10)
+    for i in range(5):
+        buf.add(i, i + 0.1, i + 0.2)
+
+    states, policies, values = buf.sample(3)
+    assert len(states) == 3
+    assert len(buf) == 5
+
+
+def test_lmdb_replay_buffer_prioritized(tmp_path):
+    path = tmp_path / "buffer.lmdb"
+    buf = LMDBReplayBuffer(str(path), capacity=5)
+    for i in range(5):
+        buf.add(i, i + 0.1, i + 0.2, priority=float(i + 1))
+
+    np.random.seed(0)
+    states1, _, _ = buf.sample_prioritized(3)
+    np.random.seed(0)
+    states2, _, _ = buf.sample_prioritized(3)
+    assert states1 == states2


### PR DESCRIPTION
## Summary
- implement `LMDBReplayBuffer` for large datasets
- export the new buffer in `chess_ai.__init__`
- list `lmdb` as dependency
- test new buffer
- update README roadmap checkboxes and changelog

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845808173788325b3f56ab5ba3bbff4