### PR TITLE
Use Makefile build for NNUE engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ __pycache__/
 *.pyc
 
 superengine/build/
+superengine/make-build/
 chess_ai.egg-info/

--- a/README.md
+++ b/README.md
@@ -89,14 +89,9 @@ Per `--play-white` wählst du deine Farbe.
 ### C++-Engine nutzen
 
 Die Verzeichnisse unter `superengine/` enthalten eine experimentelle
-C++-Engine. Sie wird beim Aufruf von `./scripts/install.sh` automatisch mit
-`cmake` und `make` gebaut. Anschließend kannst du in `superengine/build` die
-erzeugten Testprogramme ausführen, z.B.:
-
-```bash
-cd superengine/build
-ctest
-```
+C++-Engine. Beim Aufruf von `./scripts/install.sh` wird sie nun
+über ein kleines `Makefile` gebaut. Das erzeugte Binary findest du
+anschließend im Ordner `superengine/make-build`.
 
 Die Datei `main.cpp` demonstriert zudem eine einfache UCI-Schnittstelle, die du
 nach einem eigenen Build als Einstieg für weitere Experimente verwenden kannst.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,11 +12,8 @@ fi
 if [ -d "superengine" ]; then
   echo "Building superengine..."
   cd superengine
-  mkdir -p build
-  cd build
-  cmake ..
   make -j$(nproc)
-  cd ../..
+  cd ..
 fi
 
 echo "Setup complete."

--- a/superengine/Makefile
+++ b/superengine/Makefile
@@ -1,0 +1,24 @@
+CXX ?= g++
+BUILD_DIR ?= make-build
+CXXFLAGS ?= -std=c++20 -O3 -march=native -flto -Iengine
+LDFLAGS ?= -pthread
+
+SRC = engine/bitboard.cpp engine/movegen.cpp engine/nnue_eval.cpp engine/position.cpp engine/search.cpp engine/uci.cpp main.cpp
+OBJ = $(addprefix $(BUILD_DIR)/,$(notdir $(SRC:.cpp=.o)))
+
+all: $(BUILD_DIR)/superengine
+	$(CXX) $(CXXFLAGS) $(OBJ) $(LDFLAGS) -o $(BUILD_DIR)/superengine
+
+$(BUILD_DIR)/%.o: engine/%.cpp | $(BUILD_DIR)
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/main.o: main.cpp | $(BUILD_DIR)
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+.PHONY: all clean


### PR DESCRIPTION
## Summary
- add a simple `Makefile` to compile the C++ engine
- update the install script to call `make`
- document the new build step
- ignore the new build directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ac4d323c8325997b1094fc7b61f6