### PR TITLE
Add C++ CI with format checks, sanitizers and coverage

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 120

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -1,0 +1,37 @@
+name: C++ CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake clang-format lcov
+      - name: clang-format
+        run: |
+          find superengine -name '*.cpp' -o -name '*.h' | xargs clang-format --dry-run --Werror
+
+      - name: Configure
+        run: cmake -B build -S superengine -DCMAKE_BUILD_TYPE=Debug -DENABLE_SANITIZER=ON -DENABLE_COVERAGE=ON
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Run tests
+        run: |
+          cd build && ctest --output-on-failure
+
+      - name: Capture coverage
+        run: |
+          lcov --capture --directory build --output-file coverage.info
+          lcov --remove coverage.info '/usr/*' --output-file coverage.info
+          lcov --list coverage.info
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.info

--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ python scripts/train.py --games 5 --epochs 3 --simulations 50
 
 Während des Trainings erscheinen nun kurze Statistiken zu jedem Epoch.
 
+### GPU Setup
+
+Falls deine GPU von der offiziellen PyTorch-Distribution nicht unterstützt wird,
+musst du PyTorch selbst kompilieren. Setze dazu beispielsweise
+
+```bash
+export TORCH_CUDA_ARCH_LIST="12.0;10.0;8.6;8.0;7.5;7.0;6.1"
+git clone --recursive https://github.com/pytorch/pytorch
+cd pytorch && python setup.py install
+```
+
+Danach erkennt `torch.cuda.is_available()` die RTX 5070 korrekt und das Training
+nutzt die GPU.
+
 ### Gegen die KI spielen
 
 Nach dem Training kannst du mit folgendem Skript gegen das neueste Netz
@@ -175,7 +189,7 @@ Repository verfolgen kannst.
 #### 1.4 Tests & CI
 
 - [x] Perft‑Tests (Depth 1–5)
-- [ ] clang‑format & Sanitizer in der CI
+ - [x] clang‑format & Sanitizer in der CI
  - [x] Coverage‑Reporting (optional)
 
 ### 2. Python‑Komponente (chess_ai)

--- a/superengine/CMakeLists.txt
+++ b/superengine/CMakeLists.txt
@@ -3,6 +3,20 @@ project(SuperEngine VERSION 0.1 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=native -flto")
 
+# Optional build flags for CI
+option(ENABLE_SANITIZER "Enable address/undefined sanitizers" OFF)
+option(ENABLE_COVERAGE "Enable gcov code coverage" OFF)
+
+if(ENABLE_SANITIZER)
+  add_compile_options(-fsanitize=address,undefined -fno-omit-frame-pointer)
+  add_link_options(-fsanitize=address,undefined)
+endif()
+
+if(ENABLE_COVERAGE)
+  add_compile_options(--coverage -O0)
+  add_link_options(--coverage)
+endif()
+
 include(FetchContent)
 FetchContent_Declare(
   Catch2

--- a/superengine/engine/bitboard.cpp
+++ b/superengine/engine/bitboard.cpp
@@ -12,4 +12,4 @@ Bitboard north_west(Bitboard b) { return (b & ~FILE_A) << 7; }
 Bitboard south_east(Bitboard b) { return (b & ~FILE_H) >> 7; }
 Bitboard south_west(Bitboard b) { return (b & ~FILE_A) >> 9; }
 
-}
+}  // namespace bb

--- a/superengine/engine/bitboard.h
+++ b/superengine/engine/bitboard.h
@@ -3,26 +3,26 @@
 using Bitboard = uint64_t;
 
 namespace bb {
-    constexpr Bitboard FILE_A = 0x0101010101010101ULL;
-    constexpr Bitboard FILE_H = 0x8080808080808080ULL;
-    constexpr Bitboard RANK_1 = 0xFFULL;
-    constexpr Bitboard RANK_2 = 0xFFULL << 8;
-    constexpr Bitboard RANK_7 = 0xFFULL << 48;
-    constexpr Bitboard RANK_8 = 0xFFULL << 56;
+constexpr Bitboard FILE_A = 0x0101010101010101ULL;
+constexpr Bitboard FILE_H = 0x8080808080808080ULL;
+constexpr Bitboard RANK_1 = 0xFFULL;
+constexpr Bitboard RANK_2 = 0xFFULL << 8;
+constexpr Bitboard RANK_7 = 0xFFULL << 48;
+constexpr Bitboard RANK_8 = 0xFFULL << 56;
 
-    inline int pop_lsb(Bitboard &b) {
-        int idx = __builtin_ctzll(b);
-        b &= b - 1;
-        return idx;
-    }
-
-    Bitboard north_one(Bitboard b);
-    Bitboard south_one(Bitboard b);
-    Bitboard east_one(Bitboard b);
-    Bitboard west_one(Bitboard b);
-
-    Bitboard north_east(Bitboard b);
-    Bitboard north_west(Bitboard b);
-    Bitboard south_east(Bitboard b);
-    Bitboard south_west(Bitboard b);
+inline int pop_lsb(Bitboard &b) {
+    int idx = __builtin_ctzll(b);
+    b &= b - 1;
+    return idx;
 }
+
+Bitboard north_one(Bitboard b);
+Bitboard south_one(Bitboard b);
+Bitboard east_one(Bitboard b);
+Bitboard west_one(Bitboard b);
+
+Bitboard north_east(Bitboard b);
+Bitboard north_west(Bitboard b);
+Bitboard south_east(Bitboard b);
+Bitboard south_west(Bitboard b);
+}  // namespace bb

--- a/superengine/engine/movegen.cpp
+++ b/superengine/engine/movegen.cpp
@@ -1,4 +1,5 @@
 #include "movegen.h"
+
 #include <cstring>
 
 namespace movegen {
@@ -7,41 +8,43 @@ uint64_t KNIGHT_ATTACKS[64];
 uint64_t KING_ATTACKS[64];
 
 static void init_knights() {
-    for(int sq=0; sq<64; ++sq) {
-        int r = sq/8, f=sq%8;
-        uint64_t mask=0ULL;
-        const int dr[8]={2,2,-2,-2,1,1,-1,-1};
-        const int df[8]={1,-1,1,-1,2,-2,2,-2};
-        for(int i=0;i<8;++i){
-            int nr=r+dr[i], nf=f+df[i];
-            if(nr>=0 && nr<8 && nf>=0 && nf<8)
-                mask|=1ULL<<(nr*8+nf);
+    for (int sq = 0; sq < 64; ++sq) {
+        int r = sq / 8, f = sq % 8;
+        uint64_t mask = 0ULL;
+        const int dr[8] = {2, 2, -2, -2, 1, 1, -1, -1};
+        const int df[8] = {1, -1, 1, -1, 2, -2, 2, -2};
+        for (int i = 0; i < 8; ++i) {
+            int nr = r + dr[i], nf = f + df[i];
+            if (nr >= 0 && nr < 8 && nf >= 0 && nf < 8) mask |= 1ULL << (nr * 8 + nf);
         }
-        KNIGHT_ATTACKS[sq]=mask;
+        KNIGHT_ATTACKS[sq] = mask;
     }
 }
 
 static void init_kings() {
-    for(int sq=0; sq<64; ++sq){
-        int r = sq/8, f=sq%8;
-        uint64_t mask=0ULL;
-        for(int dr=-1; dr<=1; ++dr){
-            for(int df=-1; df<=1; ++df){
-                if(dr==0 && df==0) continue;
-                int nr=r+dr, nf=f+df;
-                if(nr>=0 && nr<8 && nf>=0 && nf<8)
-                    mask |= 1ULL<<(nr*8+nf);
+    for (int sq = 0; sq < 64; ++sq) {
+        int r = sq / 8, f = sq % 8;
+        uint64_t mask = 0ULL;
+        for (int dr = -1; dr <= 1; ++dr) {
+            for (int df = -1; df <= 1; ++df) {
+                if (dr == 0 && df == 0) continue;
+                int nr = r + dr, nf = f + df;
+                if (nr >= 0 && nr < 8 && nf >= 0 && nf < 8) mask |= 1ULL << (nr * 8 + nf);
             }
         }
-        KING_ATTACKS[sq]=mask;
+        KING_ATTACKS[sq] = mask;
     }
 }
 
-void init_attack_tables(){
-    static bool init=false; if(init) return; init=true; init_knights(); init_kings();
+void init_attack_tables() {
+    static bool init = false;
+    if (init) return;
+    init = true;
+    init_knights();
+    init_kings();
 }
 
-void generate_pawn_moves(const Position& pos, MoveList& out){
+void generate_pawn_moves(const Position& pos, MoveList& out) {
     Color stm = pos.side;
     Bitboard wp = pos.piece_bb[WHITE][PAWN];
     Bitboard bp = pos.piece_bb[BLACK][PAWN];
@@ -49,144 +52,144 @@ void generate_pawn_moves(const Position& pos, MoveList& out){
     Bitboard occW = pos.occupied_bb[WHITE];
     Bitboard occB = pos.occupied_bb[BLACK];
 
-    if(stm == WHITE){
-    // white single push
-    Bitboard single = (wp<<8) & ~occ;
-    Bitboard promo_rank = bb::RANK_8;
-    Bitboard promo_single = single & promo_rank;
-    Bitboard normal_single = single & ~promo_rank;
-    while(normal_single){
-        int to = bb::pop_lsb(normal_single);
-        int from = to-8;
-        out.push_back({from,to,0});
-    }
-    while(promo_single){
-        int to = bb::pop_lsb(promo_single);
-        int from = to-8;
-        for(int p=1;p<=4;++p) out.push_back({from,to,p});
-    }
-    // white double
-    Bitboard rank2 = bb::RANK_2;
-    Bitboard single_from_rank2 = ((wp & rank2)<<8) & ~occ;
-    Bitboard dbl = (single_from_rank2<<8) & ~occ;
-    while(dbl){
-        int to = bb::pop_lsb(dbl);
-        int from = to-16;
-        out.push_back({from,to,0});
-    }
-    // captures left/right
-    Bitboard left_diag = (wp & ~bb::FILE_A) << 7;
-    Bitboard right_diag = (wp & ~bb::FILE_H) << 9;
-    Bitboard left = left_diag & occB;
-    Bitboard right = right_diag & occB;
-    Bitboard ep_target = pos.en_passant==-1 ? 0ULL : (1ULL << pos.en_passant);
-    Bitboard ep_left = left_diag & ep_target;
-    Bitboard ep_right = right_diag & ep_target;
-    Bitboard promo_left = left & promo_rank;
-    Bitboard normal_left = left & ~promo_rank;
-    while(normal_left){
-        int to = bb::pop_lsb(normal_left);
-        int from = to-7;
-        out.push_back({from,to,0});
-    }
-    while(promo_left){
-        int to = bb::pop_lsb(promo_left);
-        int from = to-7;
-        for(int p=1;p<=4;++p) out.push_back({from,to,p});
-    }
-    Bitboard promo_right = right & promo_rank;
-    Bitboard normal_right = right & ~promo_rank;
-    while(normal_right){
-        int to = bb::pop_lsb(normal_right);
-        int from = to-9;
-        out.push_back({from,to,0});
-    }
-    while(promo_right){
-        int to = bb::pop_lsb(promo_right);
-        int from = to-9;
-        for(int p=1;p<=4;++p) out.push_back({from,to,p});
-    }
-    while(ep_left){
-        int to = bb::pop_lsb(ep_left);
-        int from = to-7;
-        out.push_back({from,to,0});
-    }
-    while(ep_right){
-        int to = bb::pop_lsb(ep_right);
-        int from = to-9;
-        out.push_back({from,to,0});
-    }
+    if (stm == WHITE) {
+        // white single push
+        Bitboard single = (wp << 8) & ~occ;
+        Bitboard promo_rank = bb::RANK_8;
+        Bitboard promo_single = single & promo_rank;
+        Bitboard normal_single = single & ~promo_rank;
+        while (normal_single) {
+            int to = bb::pop_lsb(normal_single);
+            int from = to - 8;
+            out.push_back({from, to, 0});
+        }
+        while (promo_single) {
+            int to = bb::pop_lsb(promo_single);
+            int from = to - 8;
+            for (int p = 1; p <= 4; ++p) out.push_back({from, to, p});
+        }
+        // white double
+        Bitboard rank2 = bb::RANK_2;
+        Bitboard single_from_rank2 = ((wp & rank2) << 8) & ~occ;
+        Bitboard dbl = (single_from_rank2 << 8) & ~occ;
+        while (dbl) {
+            int to = bb::pop_lsb(dbl);
+            int from = to - 16;
+            out.push_back({from, to, 0});
+        }
+        // captures left/right
+        Bitboard left_diag = (wp & ~bb::FILE_A) << 7;
+        Bitboard right_diag = (wp & ~bb::FILE_H) << 9;
+        Bitboard left = left_diag & occB;
+        Bitboard right = right_diag & occB;
+        Bitboard ep_target = pos.en_passant == -1 ? 0ULL : (1ULL << pos.en_passant);
+        Bitboard ep_left = left_diag & ep_target;
+        Bitboard ep_right = right_diag & ep_target;
+        Bitboard promo_left = left & promo_rank;
+        Bitboard normal_left = left & ~promo_rank;
+        while (normal_left) {
+            int to = bb::pop_lsb(normal_left);
+            int from = to - 7;
+            out.push_back({from, to, 0});
+        }
+        while (promo_left) {
+            int to = bb::pop_lsb(promo_left);
+            int from = to - 7;
+            for (int p = 1; p <= 4; ++p) out.push_back({from, to, p});
+        }
+        Bitboard promo_right = right & promo_rank;
+        Bitboard normal_right = right & ~promo_rank;
+        while (normal_right) {
+            int to = bb::pop_lsb(normal_right);
+            int from = to - 9;
+            out.push_back({from, to, 0});
+        }
+        while (promo_right) {
+            int to = bb::pop_lsb(promo_right);
+            int from = to - 9;
+            for (int p = 1; p <= 4; ++p) out.push_back({from, to, p});
+        }
+        while (ep_left) {
+            int to = bb::pop_lsb(ep_left);
+            int from = to - 7;
+            out.push_back({from, to, 0});
+        }
+        while (ep_right) {
+            int to = bb::pop_lsb(ep_right);
+            int from = to - 9;
+            out.push_back({from, to, 0});
+        }
     }
 
-    if(stm == BLACK){
-    // black moves
-    Bitboard singleB = (bp>>8) & ~occ;
-    Bitboard promo_rankB = bb::RANK_1;
-    Bitboard promo_singleB = singleB & promo_rankB;
-    Bitboard normal_singleB = singleB & ~promo_rankB;
-    while(normal_singleB){
-        int to=bb::pop_lsb(normal_singleB);
-        int from=to+8;
-        out.push_back({from,to,0});
-    }
-    while(promo_singleB){
-        int to=bb::pop_lsb(promo_singleB);
-        int from=to+8;
-        for(int p=1;p<=4;++p) out.push_back({from,to,p});
-    }
-    Bitboard rank7 = bb::RANK_7;
-    Bitboard single_from_rank7 = ((bp & rank7)>>8) & ~occ;
-    Bitboard dblB = (single_from_rank7>>8) & ~occ;
-    while(dblB){
-        int to=bb::pop_lsb(dblB);
-        int from=to+16;
-        out.push_back({from,to,0});
-    }
-    Bitboard left_diagB = (bp & ~bb::FILE_H) >> 9;
-    Bitboard right_diagB = (bp & ~bb::FILE_A) >> 7;
-    Bitboard leftB = left_diagB & occW;
-    Bitboard rightB = right_diagB & occW;
-    Bitboard ep_targetB = pos.en_passant==-1 ? 0ULL : (1ULL << pos.en_passant);
-    Bitboard ep_leftB = left_diagB & ep_targetB;
-    Bitboard ep_rightB = right_diagB & ep_targetB;
-    Bitboard promo_leftB = leftB & promo_rankB;
-    Bitboard normal_leftB = leftB & ~promo_rankB;
-    while(normal_leftB){
-        int to=bb::pop_lsb(normal_leftB);
-        int from=to+9;
-        out.push_back({from,to,0});
-    }
-    while(promo_leftB){
-        int to=bb::pop_lsb(promo_leftB);
-        int from=to+9;
-        for(int p=1;p<=4;++p) out.push_back({from,to,p});
-    }
-    while(ep_leftB){
-        int to = bb::pop_lsb(ep_leftB);
-        int from = to+9;
-        out.push_back({from,to,0});
-    }
-    Bitboard promo_rightB = rightB & promo_rankB;
-    Bitboard normal_rightB = rightB & ~promo_rankB;
-    while(normal_rightB){
-        int to=bb::pop_lsb(normal_rightB);
-        int from=to+7;
-        out.push_back({from,to,0});
-    }
-    while(promo_rightB){
-        int to=bb::pop_lsb(promo_rightB);
-        int from=to+7;
-        for(int p=1;p<=4;++p) out.push_back({from,to,p});
-    }
-    while(ep_rightB){
-        int to = bb::pop_lsb(ep_rightB);
-        int from = to+7;
-        out.push_back({from,to,0});
-    }
+    if (stm == BLACK) {
+        // black moves
+        Bitboard singleB = (bp >> 8) & ~occ;
+        Bitboard promo_rankB = bb::RANK_1;
+        Bitboard promo_singleB = singleB & promo_rankB;
+        Bitboard normal_singleB = singleB & ~promo_rankB;
+        while (normal_singleB) {
+            int to = bb::pop_lsb(normal_singleB);
+            int from = to + 8;
+            out.push_back({from, to, 0});
+        }
+        while (promo_singleB) {
+            int to = bb::pop_lsb(promo_singleB);
+            int from = to + 8;
+            for (int p = 1; p <= 4; ++p) out.push_back({from, to, p});
+        }
+        Bitboard rank7 = bb::RANK_7;
+        Bitboard single_from_rank7 = ((bp & rank7) >> 8) & ~occ;
+        Bitboard dblB = (single_from_rank7 >> 8) & ~occ;
+        while (dblB) {
+            int to = bb::pop_lsb(dblB);
+            int from = to + 16;
+            out.push_back({from, to, 0});
+        }
+        Bitboard left_diagB = (bp & ~bb::FILE_H) >> 9;
+        Bitboard right_diagB = (bp & ~bb::FILE_A) >> 7;
+        Bitboard leftB = left_diagB & occW;
+        Bitboard rightB = right_diagB & occW;
+        Bitboard ep_targetB = pos.en_passant == -1 ? 0ULL : (1ULL << pos.en_passant);
+        Bitboard ep_leftB = left_diagB & ep_targetB;
+        Bitboard ep_rightB = right_diagB & ep_targetB;
+        Bitboard promo_leftB = leftB & promo_rankB;
+        Bitboard normal_leftB = leftB & ~promo_rankB;
+        while (normal_leftB) {
+            int to = bb::pop_lsb(normal_leftB);
+            int from = to + 9;
+            out.push_back({from, to, 0});
+        }
+        while (promo_leftB) {
+            int to = bb::pop_lsb(promo_leftB);
+            int from = to + 9;
+            for (int p = 1; p <= 4; ++p) out.push_back({from, to, p});
+        }
+        while (ep_leftB) {
+            int to = bb::pop_lsb(ep_leftB);
+            int from = to + 9;
+            out.push_back({from, to, 0});
+        }
+        Bitboard promo_rightB = rightB & promo_rankB;
+        Bitboard normal_rightB = rightB & ~promo_rankB;
+        while (normal_rightB) {
+            int to = bb::pop_lsb(normal_rightB);
+            int from = to + 7;
+            out.push_back({from, to, 0});
+        }
+        while (promo_rightB) {
+            int to = bb::pop_lsb(promo_rightB);
+            int from = to + 7;
+            for (int p = 1; p <= 4; ++p) out.push_back({from, to, p});
+        }
+        while (ep_rightB) {
+            int to = bb::pop_lsb(ep_rightB);
+            int from = to + 7;
+            out.push_back({from, to, 0});
+        }
     }
 }
 
-void generate_knight_moves(const Position& pos, MoveList& out){
+void generate_knight_moves(const Position& pos, MoveList& out) {
     init_attack_tables();
     Color stm = pos.side;
     Bitboard wn = pos.piece_bb[WHITE][KNIGHT];
@@ -194,174 +197,187 @@ void generate_knight_moves(const Position& pos, MoveList& out){
     Bitboard occW = pos.occupied_bb[WHITE];
     Bitboard occB = pos.occupied_bb[BLACK];
 
-    if(stm == WHITE){
-        while(wn){
+    if (stm == WHITE) {
+        while (wn) {
             int from = bb::pop_lsb(wn);
             Bitboard targets = KNIGHT_ATTACKS[from] & ~occW;
-            while(targets){
+            while (targets) {
                 int to = bb::pop_lsb(targets);
-                out.push_back({from,to,0});
+                out.push_back({from, to, 0});
             }
         }
     } else {
-        while(bn){
+        while (bn) {
             int from = bb::pop_lsb(bn);
             Bitboard targets = KNIGHT_ATTACKS[from] & ~occB;
-            while(targets){
+            while (targets) {
                 int to = bb::pop_lsb(targets);
-                out.push_back({from,to,0});
+                out.push_back({from, to, 0});
             }
         }
     }
 }
 
-Bitboard bishop_attacks(int from, Bitboard blockers){
-    Bitboard attacks=0ULL;
-    int f=from%8, r=from/8;
-    for(int df=1, dr=1; df<=1; ++df){ /* dummy to use loops */ }
-    auto add_dir=[&](int df, int dr){
-        for(int s=1;;++s){
-            int nf=f+df*s, nr=r+dr*s;
-            if(nf<0||nf>=8||nr<0||nr>=8) break;
-            int sq=nr*8+nf; Bitboard m=1ULL<<sq; attacks|=m; if(blockers&m) break;
+Bitboard bishop_attacks(int from, Bitboard blockers) {
+    Bitboard attacks = 0ULL;
+    int f = from % 8, r = from / 8;
+    for (int df = 1, dr = 1; df <= 1; ++df) { /* dummy to use loops */
+    }
+    auto add_dir = [&](int df, int dr) {
+        for (int s = 1;; ++s) {
+            int nf = f + df * s, nr = r + dr * s;
+            if (nf < 0 || nf >= 8 || nr < 0 || nr >= 8) break;
+            int sq = nr * 8 + nf;
+            Bitboard m = 1ULL << sq;
+            attacks |= m;
+            if (blockers & m) break;
         }
     };
-    add_dir(1,1); add_dir(-1,1); add_dir(1,-1); add_dir(-1,-1);
+    add_dir(1, 1);
+    add_dir(-1, 1);
+    add_dir(1, -1);
+    add_dir(-1, -1);
     return attacks;
 }
 
-Bitboard rook_attacks(int from, Bitboard blockers){
-    Bitboard attacks=0ULL;
-    int f=from%8, r=from/8;
-    auto add_dir=[&](int df, int dr){
-        for(int s=1;;++s){
-            int nf=f+df*s, nr=r+dr*s;
-            if(nf<0||nf>=8||nr<0||nr>=8) break;
-            int sq=nr*8+nf; Bitboard m=1ULL<<sq; attacks|=m; if(blockers&m) break;
+Bitboard rook_attacks(int from, Bitboard blockers) {
+    Bitboard attacks = 0ULL;
+    int f = from % 8, r = from / 8;
+    auto add_dir = [&](int df, int dr) {
+        for (int s = 1;; ++s) {
+            int nf = f + df * s, nr = r + dr * s;
+            if (nf < 0 || nf >= 8 || nr < 0 || nr >= 8) break;
+            int sq = nr * 8 + nf;
+            Bitboard m = 1ULL << sq;
+            attacks |= m;
+            if (blockers & m) break;
         }
     };
-    add_dir(1,0); add_dir(-1,0); add_dir(0,1); add_dir(0,-1);
+    add_dir(1, 0);
+    add_dir(-1, 0);
+    add_dir(0, 1);
+    add_dir(0, -1);
     return attacks;
 }
 
-void generate_bishop_moves(const Position& pos, MoveList& out){
+void generate_bishop_moves(const Position& pos, MoveList& out) {
     Color stm = pos.side;
     Bitboard occOwn = pos.occupied_bb[stm];
     Bitboard pieces = pos.piece_bb[stm][BISHOP];
     Bitboard blockers = pos.all_occupied;
-    while(pieces){
+    while (pieces) {
         int from = bb::pop_lsb(pieces);
         Bitboard targets = bishop_attacks(from, blockers) & ~occOwn;
-        while(targets){
+        while (targets) {
             int to = bb::pop_lsb(targets);
-            out.push_back({from,to,0});
+            out.push_back({from, to, 0});
         }
     }
 }
 
-void generate_rook_moves(const Position& pos, MoveList& out){
+void generate_rook_moves(const Position& pos, MoveList& out) {
     Color stm = pos.side;
     Bitboard occOwn = pos.occupied_bb[stm];
     Bitboard pieces = pos.piece_bb[stm][ROOK];
     Bitboard blockers = pos.all_occupied;
-    while(pieces){
+    while (pieces) {
         int from = bb::pop_lsb(pieces);
         Bitboard targets = rook_attacks(from, blockers) & ~occOwn;
-        while(targets){
+        while (targets) {
             int to = bb::pop_lsb(targets);
-            out.push_back({from,to,0});
+            out.push_back({from, to, 0});
         }
     }
 }
 
-void generate_queen_moves(const Position& pos, MoveList& out){
+void generate_queen_moves(const Position& pos, MoveList& out) {
     Color stm = pos.side;
     Bitboard occOwn = pos.occupied_bb[stm];
     Bitboard pieces = pos.piece_bb[stm][QUEEN];
     Bitboard blockers = pos.all_occupied;
-    while(pieces){
+    while (pieces) {
         int from = bb::pop_lsb(pieces);
         Bitboard targets = queen_attacks(from, blockers) & ~occOwn;
-        while(targets){
+        while (targets) {
             int to = bb::pop_lsb(targets);
-            out.push_back({from,to,0});
+            out.push_back({from, to, 0});
         }
     }
 }
 
-void generate_sliding_moves(const Position& pos, MoveList& out){
+void generate_sliding_moves(const Position& pos, MoveList& out) {
     Color stm = pos.side;
     Bitboard occW = pos.occupied_bb[WHITE];
     Bitboard occB = pos.occupied_bb[BLACK];
-    auto gen_dir = [&](int from, int df, int dr, Bitboard blockers){
-        int f = from % 8; int r = from / 8;
-        for(int s=1;;++s){
-            int nf=f+df*s, nr=r+dr*s;
-            if(nf<0||nf>=8||nr<0||nr>=8) break;
-            int to = nr*8+nf;
-            Bitboard mask = 1ULL<<to;
-            if(blockers & mask){
-                if((stm==WHITE?occB:occW)&mask) out.push_back({from,to,0});
+    auto gen_dir = [&](int from, int df, int dr, Bitboard blockers) {
+        int f = from % 8;
+        int r = from / 8;
+        for (int s = 1;; ++s) {
+            int nf = f + df * s, nr = r + dr * s;
+            if (nf < 0 || nf >= 8 || nr < 0 || nr >= 8) break;
+            int to = nr * 8 + nf;
+            Bitboard mask = 1ULL << to;
+            if (blockers & mask) {
+                if ((stm == WHITE ? occB : occW) & mask) out.push_back({from, to, 0});
                 break;
             }
-            out.push_back({from,to,0});
+            out.push_back({from, to, 0});
         }
     };
 
     Bitboard bishops = pos.piece_bb[stm][BISHOP];
-    Bitboard rooks   = pos.piece_bb[stm][ROOK];
-    Bitboard queens  = pos.piece_bb[stm][QUEEN];
+    Bitboard rooks = pos.piece_bb[stm][ROOK];
+    Bitboard queens = pos.piece_bb[stm][QUEEN];
     Bitboard blockers = pos.all_occupied;
 
     Bitboard pieces = bishops | queens;
-    while(pieces){
+    while (pieces) {
         int from = bb::pop_lsb(pieces);
-        gen_dir(from,1,1,blockers);
-        gen_dir(from,-1,1,blockers);
-        gen_dir(from,1,-1,blockers);
-        gen_dir(from,-1,-1,blockers);
+        gen_dir(from, 1, 1, blockers);
+        gen_dir(from, -1, 1, blockers);
+        gen_dir(from, 1, -1, blockers);
+        gen_dir(from, -1, -1, blockers);
     }
 
     pieces = rooks | queens;
-    while(pieces){
+    while (pieces) {
         int from = bb::pop_lsb(pieces);
-        gen_dir(from,1,0,blockers);
-        gen_dir(from,-1,0,blockers);
-        gen_dir(from,0,1,blockers);
-        gen_dir(from,0,-1,blockers);
+        gen_dir(from, 1, 0, blockers);
+        gen_dir(from, -1, 0, blockers);
+        gen_dir(from, 0, 1, blockers);
+        gen_dir(from, 0, -1, blockers);
     }
 }
 
-void generate_king_moves(const Position& pos, MoveList& out){
+void generate_king_moves(const Position& pos, MoveList& out) {
     Color stm = pos.side;
     Bitboard king = pos.piece_bb[stm][KING];
     int from = bb::pop_lsb(king);
     Bitboard occOwn = pos.occupied_bb[stm];
-    const int dr[8]={1,1,1,0,0,-1,-1,-1};
-    const int df[8]={-1,0,1,-1,1,-1,0,1};
-    for(int i=0;i<8;++i){
-        int nf=(from%8)+df[i], nr=(from/8)+dr[i];
-        if(nf<0||nf>=8||nr<0||nr>=8) continue;
-        int to=nr*8+nf;
-        if(!(occOwn & (1ULL<<to)))
-            out.push_back({from,to,0});
+    const int dr[8] = {1, 1, 1, 0, 0, -1, -1, -1};
+    const int df[8] = {-1, 0, 1, -1, 1, -1, 0, 1};
+    for (int i = 0; i < 8; ++i) {
+        int nf = (from % 8) + df[i], nr = (from / 8) + dr[i];
+        if (nf < 0 || nf >= 8 || nr < 0 || nr >= 8) continue;
+        int to = nr * 8 + nf;
+        if (!(occOwn & (1ULL << to))) out.push_back({from, to, 0});
     }
     // castling very simplified
-    if(stm==WHITE){
-        if((pos.castling_rights & 1) && !(pos.all_occupied & ((1ULL<<5)|(1ULL<<6))))
-            out.push_back({4,6,0});
-        if((pos.castling_rights & 2) && !(pos.all_occupied & ((1ULL<<1)|(1ULL<<2)|(1ULL<<3))))
-            out.push_back({4,2,0});
-    }else{
-        if((pos.castling_rights & 4) && !(pos.all_occupied & ((1ULL<<61)|(1ULL<<62))))
-            out.push_back({60,62,0});
-        if((pos.castling_rights & 8) && !(pos.all_occupied & ((1ULL<<57)|(1ULL<<58)|(1ULL<<59))))
-            out.push_back({60,58,0});
+    if (stm == WHITE) {
+        if ((pos.castling_rights & 1) && !(pos.all_occupied & ((1ULL << 5) | (1ULL << 6)))) out.push_back({4, 6, 0});
+        if ((pos.castling_rights & 2) && !(pos.all_occupied & ((1ULL << 1) | (1ULL << 2) | (1ULL << 3))))
+            out.push_back({4, 2, 0});
+    } else {
+        if ((pos.castling_rights & 4) && !(pos.all_occupied & ((1ULL << 61) | (1ULL << 62))))
+            out.push_back({60, 62, 0});
+        if ((pos.castling_rights & 8) && !(pos.all_occupied & ((1ULL << 57) | (1ULL << 58) | (1ULL << 59))))
+            out.push_back({60, 58, 0});
     }
 }
 
-MoveList generate_pseudo_moves(const Position& pos){
-    MoveList ml; ml.reserve(64);
+MoveList generate_pseudo_moves(const Position& pos) {
+    MoveList ml;
+    ml.reserve(64);
     generate_pawn_moves(pos, ml);
     generate_knight_moves(pos, ml);
     generate_sliding_moves(pos, ml);
@@ -369,15 +385,15 @@ MoveList generate_pseudo_moves(const Position& pos){
     return ml;
 }
 
-MoveList generate_moves(const Position& pos){
+MoveList generate_moves(const Position& pos) {
     MoveList ml;
     auto pseudo = generate_pseudo_moves(pos);
-    for(const auto& m: pseudo){
+    for (const auto& m : pseudo) {
         Position next = pos;
         next.do_move(m);
-        if(!next.in_check(pos.side)) ml.push_back(m);
+        if (!next.in_check(pos.side)) ml.push_back(m);
     }
     return ml;
 }
 
-} // namespace movegen
+}  // namespace movegen

--- a/superengine/engine/movegen.h
+++ b/superengine/engine/movegen.h
@@ -1,16 +1,21 @@
 #pragma once
-#include <vector>
 #include <cstdint>
+#include <vector>
+
 #include "bitboard.h"
 #include "position.h"
 
 namespace movegen {
 
-struct Move { int from; int to; int promo; }; // simple struct
+struct Move {
+    int from;
+    int to;
+    int promo;
+};  // simple struct
 using MoveList = std::vector<Move>;
 
 // encode/decode helpers for tests or uci
-inline uint32_t encode_move(int from, int to, int promo=0) {
+inline uint32_t encode_move(int from, int to, int promo = 0) {
     return (from & 0x3F) | ((to & 0x3F) << 6) | ((promo & 0x7) << 12);
 }
 
@@ -37,21 +42,18 @@ void generate_king_moves(const Position& pos, MoveList& out);
 MoveList generate_pseudo_moves(const Position& pos);
 
 // temporary alias for backwards compatibility
-inline MoveList generate_pseudo_legal(const Position& pos) {
-    return generate_pseudo_moves(pos);
-}
+inline MoveList generate_pseudo_legal(const Position& pos) { return generate_pseudo_moves(pos); }
 
 // unified move generator returning only legal moves
 MoveList generate_moves(const Position& pos);
-inline MoveList generate_legal_moves(const Position& pos) {
-    return generate_moves(pos);
-}
+inline MoveList generate_legal_moves(const Position& pos) { return generate_moves(pos); }
 
 inline MoveList generate_pawn_knight(const Position& pos) {
-    MoveList ml; ml.reserve(32);
+    MoveList ml;
+    ml.reserve(32);
     generate_pawn_moves(pos, ml);
     generate_knight_moves(pos, ml);
     return ml;
 }
 
-} // namespace movegen
+}  // namespace movegen

--- a/superengine/engine/nnue_eval.cpp
+++ b/superengine/engine/nnue_eval.cpp
@@ -1,26 +1,28 @@
 #include "nnue_eval.h"
-#include "position.h"
-#include <fstream>
+
 #include <array>
 #include <cstring>
+#include <fstream>
+
+#include "position.h"
 
 nnue::Network nnue::net;
 
 static int16_t clamp_relu(int32_t x) { return x > 0 ? (x < 32767 ? x : 32767) : 0; }
 
-static int feature_index(Color c, Piece p, int sq){
-    int mirror = c==WHITE ? sq : (sq ^ 56);
-    return c*6*64 + p*64 + mirror;
+static int feature_index(Color c, Piece p, int sq) {
+    int mirror = c == WHITE ? sq : (sq ^ 56);
+    return c * 6 * 64 + p * 64 + mirror;
 }
 
-static void extract_features(const Position& pos, std::array<int16_t, nnue::INPUTS>& out){
+static void extract_features(const Position& pos, std::array<int16_t, nnue::INPUTS>& out) {
     out.fill(0);
-    for(int c=0;c<2;++c){
-        for(int p=0;p<PIECE_NB;++p){
+    for (int c = 0; c < 2; ++c) {
+        for (int p = 0; p < PIECE_NB; ++p) {
             Bitboard bb = pos.piece_bb[c][p];
-            while(bb){
+            while (bb) {
                 int sq = bb::pop_lsb(bb);
-                out[feature_index((Color)c,(Piece)p,sq)] = 1;
+                out[feature_index((Color)c, (Piece)p, sq)] = 1;
             }
         }
     }
@@ -30,23 +32,23 @@ int nnue::eval(const Position& pos) {
     std::array<int16_t, INPUTS> feats;
     extract_features(pos, feats);
     std::array<int32_t, HIDDEN1> h1{};
-    for(int i=0;i<INPUTS;++i){
-        if(!feats[i]) continue;
-        for(int j=0;j<HIDDEN1;++j){
-            h1[j] += net.w1[i*HIDDEN1 + j];
+    for (int i = 0; i < INPUTS; ++i) {
+        if (!feats[i]) continue;
+        for (int j = 0; j < HIDDEN1; ++j) {
+            h1[j] += net.w1[i * HIDDEN1 + j];
         }
     }
-    for(int j=0;j<HIDDEN1;++j) h1[j] = clamp_relu(h1[j]);
+    for (int j = 0; j < HIDDEN1; ++j) h1[j] = clamp_relu(h1[j]);
     std::array<int32_t, HIDDEN2> h2{};
-    for(int i=0;i<HIDDEN1;++i){
-        for(int j=0;j<HIDDEN2;++j){
-            h2[j] += h1[i] * net.w2[i*HIDDEN2 + j];
+    for (int i = 0; i < HIDDEN1; ++i) {
+        for (int j = 0; j < HIDDEN2; ++j) {
+            h2[j] += h1[i] * net.w2[i * HIDDEN2 + j];
         }
     }
-    for(int j=0;j<HIDDEN2;++j) h2[j] = clamp_relu(h2[j] + net.bias2[j]);
+    for (int j = 0; j < HIDDEN2; ++j) h2[j] = clamp_relu(h2[j] + net.bias2[j]);
     int32_t out = 0;
-    for(int j=0;j<HIDDEN2;++j) out += h2[j] * net.w3[j];
-    return out / 1000; // scale
+    for (int j = 0; j < HIDDEN2; ++j) out += h2[j] * net.w3[j];
+    return out / 1000;  // scale
 }
 
 void nnue::load_network(const std::string& path) {

--- a/superengine/engine/nnue_eval.h
+++ b/superengine/engine/nnue_eval.h
@@ -1,11 +1,12 @@
 #pragma once
 #include <array>
 #include <string>
+
 #include "position.h"
 
 namespace nnue {
 
-constexpr int INPUTS  = 768;
+constexpr int INPUTS = 768;
 constexpr int HIDDEN1 = 512;
 constexpr int HIDDEN2 = 256;
 constexpr int OUTPUTS = 1;
@@ -22,4 +23,4 @@ extern Network net;
 int eval(const Position& pos);
 void load_network(const std::string& path);
 
-}
+}  // namespace nnue

--- a/superengine/engine/position.cpp
+++ b/superengine/engine/position.cpp
@@ -1,215 +1,273 @@
 #include "position.h"
+
 #include "movegen.h"
 
-namespace movegen { MoveList generate_pseudo_moves(const Position& pos); }
-#include <sstream>
+namespace movegen {
+MoveList generate_pseudo_moves(const Position& pos);
+}
 #include <cctype>
+#include <sstream>
 
 Position::Position(const std::string& fen) {
     // initialize bitboards
-    for(int c=0;c<2;++c) for(int p=0;p<PIECE_NB;++p) piece_bb[c][p]=0ULL;
-    occupied_bb[WHITE]=occupied_bb[BLACK]=0ULL;
-    all_occupied=0ULL;
-    side=WHITE;
+    for (int c = 0; c < 2; ++c)
+        for (int p = 0; p < PIECE_NB; ++p) piece_bb[c][p] = 0ULL;
+    occupied_bb[WHITE] = occupied_bb[BLACK] = 0ULL;
+    all_occupied = 0ULL;
+    side = WHITE;
 
     std::istringstream ss(fen);
     std::string board, stm, castling = "-", ep = "-";
-    if (!(ss >> board >> stm))
-        return; // invalid FEN, leave empty position
+    if (!(ss >> board >> stm)) return;  // invalid FEN, leave empty position
     if (!(ss >> castling)) castling = "-";
     if (!(ss >> ep)) ep = "-";
     if (!(ss >> halfmove_clock)) halfmove_clock = 0;
     if (!(ss >> fullmove_number)) fullmove_number = 1;
 
-    side = (stm=="w"?WHITE:BLACK);
+    side = (stm == "w" ? WHITE : BLACK);
     castling_rights = 0;
-    if(castling.find('K') != std::string::npos) castling_rights |= 1;
-    if(castling.find('Q') != std::string::npos) castling_rights |= 2;
-    if(castling.find('k') != std::string::npos) castling_rights |= 4;
-    if(castling.find('q') != std::string::npos) castling_rights |= 8;
+    if (castling.find('K') != std::string::npos) castling_rights |= 1;
+    if (castling.find('Q') != std::string::npos) castling_rights |= 2;
+    if (castling.find('k') != std::string::npos) castling_rights |= 4;
+    if (castling.find('q') != std::string::npos) castling_rights |= 8;
     en_passant = -1;
-    if(ep != "-" && ep.size()==2){
-        int file = ep[0]-'a';
-        int rank = ep[1]-'1';
-        en_passant = rank*8 + file;
+    if (ep != "-" && ep.size() == 2) {
+        int file = ep[0] - 'a';
+        int rank = ep[1] - '1';
+        en_passant = rank * 8 + file;
     }
 
-    int sq=56; // start at a8
-    for(char ch : board){
-        if(ch=='/'){ sq-=16; continue; }
-        if(std::isdigit(ch)){ sq+= ch-'0'; continue; }
-        Color c = std::isupper(ch)?WHITE:BLACK;
+    int sq = 56;  // start at a8
+    for (char ch : board) {
+        if (ch == '/') {
+            sq -= 16;
+            continue;
+        }
+        if (std::isdigit(ch)) {
+            sq += ch - '0';
+            continue;
+        }
+        Color c = std::isupper(ch) ? WHITE : BLACK;
         char l = std::tolower(ch);
         Piece pc;
-        switch(l){
-            case 'p': pc=PAWN; break;
-            case 'n': pc=KNIGHT; break;
-            case 'b': pc=BISHOP; break;
-            case 'r': pc=ROOK; break;
-            case 'q': pc=QUEEN; break;
-            case 'k': pc=KING; break;
-            default: continue;
+        switch (l) {
+            case 'p':
+                pc = PAWN;
+                break;
+            case 'n':
+                pc = KNIGHT;
+                break;
+            case 'b':
+                pc = BISHOP;
+                break;
+            case 'r':
+                pc = ROOK;
+                break;
+            case 'q':
+                pc = QUEEN;
+                break;
+            case 'k':
+                pc = KING;
+                break;
+            default:
+                continue;
         }
-        piece_bb[c][pc] |= 1ULL<<sq;
+        piece_bb[c][pc] |= 1ULL << sq;
         sq++;
     }
     // compute occupancy
-    for(int c=0;c<2;++c){
-        Bitboard occ=0ULL;
-        for(int p=0;p<PIECE_NB;++p) occ|=piece_bb[c][p];
-        occupied_bb[c]=occ;
+    for (int c = 0; c < 2; ++c) {
+        Bitboard occ = 0ULL;
+        for (int p = 0; p < PIECE_NB; ++p) occ |= piece_bb[c][p];
+        occupied_bb[c] = occ;
     }
-    all_occupied = occupied_bb[WHITE]|occupied_bb[BLACK];
+    all_occupied = occupied_bb[WHITE] | occupied_bb[BLACK];
 }
 
 Piece Position::piece_on(int sq) const {
-    Bitboard mask = 1ULL<<sq;
-    for(int c=0;c<2;++c){
-        for(int p=0;p<PIECE_NB;++p){
-            if(piece_bb[c][p] & mask)
-                return static_cast<Piece>(p);
+    Bitboard mask = 1ULL << sq;
+    for (int c = 0; c < 2; ++c) {
+        for (int p = 0; p < PIECE_NB; ++p) {
+            if (piece_bb[c][p] & mask) return static_cast<Piece>(p);
         }
     }
-    return PIECE_NB; // invalid
+    return PIECE_NB;  // invalid
 }
 
 bool Position::in_check(Color c) const {
     movegen::init_attack_tables();
     Bitboard king_bb = piece_bb[c][KING];
-    if(!king_bb) return false;
+    if (!king_bb) return false;
     int king_sq = __builtin_ctzll(king_bb);
-    Color o = c==WHITE?BLACK:WHITE;
-    if(movegen::KNIGHT_ATTACKS[king_sq] & piece_bb[o][KNIGHT]) return true;
-    Bitboard pawn_attacks = c==WHITE ?
-        ((piece_bb[o][PAWN] & ~bb::FILE_H) << 9 | (piece_bb[o][PAWN] & ~bb::FILE_A) << 7) :
-        ((piece_bb[o][PAWN] & ~bb::FILE_A) >> 9 | (piece_bb[o][PAWN] & ~bb::FILE_H) >> 7);
-    if(pawn_attacks & king_bb) return true;
+    Color o = c == WHITE ? BLACK : WHITE;
+    if (movegen::KNIGHT_ATTACKS[king_sq] & piece_bb[o][KNIGHT]) return true;
+    Bitboard pawn_attacks = c == WHITE
+                                ? ((piece_bb[o][PAWN] & ~bb::FILE_H) << 9 | (piece_bb[o][PAWN] & ~bb::FILE_A) << 7)
+                                : ((piece_bb[o][PAWN] & ~bb::FILE_A) >> 9 | (piece_bb[o][PAWN] & ~bb::FILE_H) >> 7);
+    if (pawn_attacks & king_bb) return true;
     Bitboard rookers = piece_bb[o][ROOK] | piece_bb[o][QUEEN];
-    if(movegen::rook_attacks(king_sq, all_occupied) & rookers) return true;
+    if (movegen::rook_attacks(king_sq, all_occupied) & rookers) return true;
     Bitboard bishops = piece_bb[o][BISHOP] | piece_bb[o][QUEEN];
-    if(movegen::bishop_attacks(king_sq, all_occupied) & bishops) return true;
-    if(movegen::KING_ATTACKS[king_sq] & piece_bb[o][KING]) return true;
+    if (movegen::bishop_attacks(king_sq, all_occupied) & bishops) return true;
+    if (movegen::KING_ATTACKS[king_sq] & piece_bb[o][KING]) return true;
     return false;
 }
 
-void Position::do_move(const movegen::Move& m){
+void Position::do_move(const movegen::Move& m) {
     Piece pc = piece_on(m.from);
     Color c = side;
-    Color opp = c==WHITE?BLACK:WHITE;
-    Bitboard from_mask = 1ULL<<m.from;
-    Bitboard to_mask   = 1ULL<<m.to;
+    Color opp = c == WHITE ? BLACK : WHITE;
+    Bitboard from_mask = 1ULL << m.from;
+    Bitboard to_mask = 1ULL << m.to;
     Piece captured_piece = piece_on(m.to);
     // update castling rights on capture of rooks
-    if(captured_piece == ROOK){
-        if(opp == WHITE){
-            if(m.to == 0) castling_rights &= ~2; // white queenside rook captured
-            if(m.to == 7) castling_rights &= ~1; // white kingside rook captured
-        }else{
-            if(m.to == 56) castling_rights &= ~8; // black queenside rook captured
-            if(m.to == 63) castling_rights &= ~4; // black kingside rook captured
+    if (captured_piece == ROOK) {
+        if (opp == WHITE) {
+            if (m.to == 0) castling_rights &= ~2;  // white queenside rook captured
+            if (m.to == 7) castling_rights &= ~1;  // white kingside rook captured
+        } else {
+            if (m.to == 56) castling_rights &= ~8;  // black queenside rook captured
+            if (m.to == 63) castling_rights &= ~4;  // black kingside rook captured
         }
     }
     // update castling rights when moving king or rook
-    if(pc == KING){
-        if(c==WHITE) castling_rights &= ~3; else castling_rights &= ~12;
+    if (pc == KING) {
+        if (c == WHITE)
+            castling_rights &= ~3;
+        else
+            castling_rights &= ~12;
     }
-    if(pc == ROOK){
-        if(c==WHITE){
-            if(m.from == 0) castling_rights &= ~2;
-            if(m.from == 7) castling_rights &= ~1;
-        }else{
-            if(m.from == 56) castling_rights &= ~8;
-            if(m.from == 63) castling_rights &= ~4;
+    if (pc == ROOK) {
+        if (c == WHITE) {
+            if (m.from == 0) castling_rights &= ~2;
+            if (m.from == 7) castling_rights &= ~1;
+        } else {
+            if (m.from == 56) castling_rights &= ~8;
+            if (m.from == 63) castling_rights &= ~4;
         }
     }
     // handle en-passant capture
-    if(pc == PAWN && m.to == en_passant && en_passant != -1){
-        Bitboard cap_mask = c==WHITE ? (to_mask>>8) : (to_mask<<8);
-        for(int p=0;p<PIECE_NB;++p) piece_bb[opp][p] &= ~cap_mask;
+    if (pc == PAWN && m.to == en_passant && en_passant != -1) {
+        Bitboard cap_mask = c == WHITE ? (to_mask >> 8) : (to_mask << 8);
+        for (int p = 0; p < PIECE_NB; ++p) piece_bb[opp][p] &= ~cap_mask;
     }
-    for(int p=0;p<PIECE_NB;++p) {
+    for (int p = 0; p < PIECE_NB; ++p) {
         piece_bb[c][p] &= ~from_mask;
         piece_bb[c][p] &= ~to_mask;
         piece_bb[opp][p] &= ~to_mask;
     }
     piece_bb[c][pc] |= to_mask;
-    if(m.promo)
-    {
+    if (m.promo) {
         piece_bb[c][pc] &= ~to_mask;
         piece_bb[c][m.promo] |= to_mask;
     }
     // handle castling rook move
-    if(pc == KING){
-        if(c==WHITE){
-            if(m.from==4 && m.to==6){
+    if (pc == KING) {
+        if (c == WHITE) {
+            if (m.from == 4 && m.to == 6) {
                 // king side
-                Bitboard rfrom=1ULL<<7, rto=1ULL<<5;
-                for(int p=0;p<PIECE_NB;++p){ piece_bb[c][p] &= ~rfrom; piece_bb[c][p] &= ~rto; }
+                Bitboard rfrom = 1ULL << 7, rto = 1ULL << 5;
+                for (int p = 0; p < PIECE_NB; ++p) {
+                    piece_bb[c][p] &= ~rfrom;
+                    piece_bb[c][p] &= ~rto;
+                }
                 piece_bb[c][ROOK] |= rto;
-            }else if(m.from==4 && m.to==2){
-                Bitboard rfrom=1ULL<<0, rto=1ULL<<3;
-                for(int p=0;p<PIECE_NB;++p){ piece_bb[c][p] &= ~rfrom; piece_bb[c][p] &= ~rto; }
+            } else if (m.from == 4 && m.to == 2) {
+                Bitboard rfrom = 1ULL << 0, rto = 1ULL << 3;
+                for (int p = 0; p < PIECE_NB; ++p) {
+                    piece_bb[c][p] &= ~rfrom;
+                    piece_bb[c][p] &= ~rto;
+                }
                 piece_bb[c][ROOK] |= rto;
             }
-        }else{
-            if(m.from==60 && m.to==62){
-                Bitboard rfrom=1ULL<<63, rto=1ULL<<61;
-                for(int p=0;p<PIECE_NB;++p){ piece_bb[c][p] &= ~rfrom; piece_bb[c][p] &= ~rto; }
+        } else {
+            if (m.from == 60 && m.to == 62) {
+                Bitboard rfrom = 1ULL << 63, rto = 1ULL << 61;
+                for (int p = 0; p < PIECE_NB; ++p) {
+                    piece_bb[c][p] &= ~rfrom;
+                    piece_bb[c][p] &= ~rto;
+                }
                 piece_bb[c][ROOK] |= rto;
-            }else if(m.from==60 && m.to==58){
-                Bitboard rfrom=1ULL<<56, rto=1ULL<<59;
-                for(int p=0;p<PIECE_NB;++p){ piece_bb[c][p] &= ~rfrom; piece_bb[c][p] &= ~rto; }
+            } else if (m.from == 60 && m.to == 58) {
+                Bitboard rfrom = 1ULL << 56, rto = 1ULL << 59;
+                for (int p = 0; p < PIECE_NB; ++p) {
+                    piece_bb[c][p] &= ~rfrom;
+                    piece_bb[c][p] &= ~rto;
+                }
                 piece_bb[c][ROOK] |= rto;
             }
         }
     }
     en_passant = -1;
-    if(pc==PAWN){
-        if(c==WHITE && m.from/8==1 && m.to/8==3)
+    if (pc == PAWN) {
+        if (c == WHITE && m.from / 8 == 1 && m.to / 8 == 3)
             en_passant = m.from + 8;
-        else if(c==BLACK && m.from/8==6 && m.to/8==4)
+        else if (c == BLACK && m.from / 8 == 6 && m.to / 8 == 4)
             en_passant = m.from - 8;
     }
     // recompute occupancy
-    for(int col=0;col<2;++col){
-        Bitboard occ=0ULL;
-        for(int p=0;p<PIECE_NB;++p) occ|=piece_bb[col][p];
-        occupied_bb[col]=occ;
+    for (int col = 0; col < 2; ++col) {
+        Bitboard occ = 0ULL;
+        for (int p = 0; p < PIECE_NB; ++p) occ |= piece_bb[col][p];
+        occupied_bb[col] = occ;
     }
-    all_occupied = occupied_bb[WHITE]|occupied_bb[BLACK];
+    all_occupied = occupied_bb[WHITE] | occupied_bb[BLACK];
     side = opp;
 }
 
 std::string Position::to_fen() const {
-    std::string board="";
-    for(int r=7;r>=0;--r){
-        int empty=0;
-        for(int f=0;f<8;++f){
-            int sq=r*8+f;
+    std::string board = "";
+    for (int r = 7; r >= 0; --r) {
+        int empty = 0;
+        for (int f = 0; f < 8; ++f) {
+            int sq = r * 8 + f;
             Piece pc = piece_on(sq);
-            if(pc==PIECE_NB){
-                empty++; continue;
+            if (pc == PIECE_NB) {
+                empty++;
+                continue;
             }
-            if(empty){ board += std::to_string(empty); empty=0; }
-            char c='?';
-            switch(pc){
-                case PAWN:c='p';break;case KNIGHT:c='n';break;case BISHOP:c='b';break;
-                case ROOK:c='r';break;case QUEEN:c='q';break;case KING:c='k';break;
-                default: break;
+            if (empty) {
+                board += std::to_string(empty);
+                empty = 0;
             }
-            if(occupied_bb[WHITE] & (1ULL<<sq)) c=toupper(c);
-            board+=c;
+            char c = '?';
+            switch (pc) {
+                case PAWN:
+                    c = 'p';
+                    break;
+                case KNIGHT:
+                    c = 'n';
+                    break;
+                case BISHOP:
+                    c = 'b';
+                    break;
+                case ROOK:
+                    c = 'r';
+                    break;
+                case QUEEN:
+                    c = 'q';
+                    break;
+                case KING:
+                    c = 'k';
+                    break;
+                default:
+                    break;
+            }
+            if (occupied_bb[WHITE] & (1ULL << sq)) c = toupper(c);
+            board += c;
         }
-        if(empty) board += std::to_string(empty);
-        if(r>0) board+='/';
+        if (empty) board += std::to_string(empty);
+        if (r > 0) board += '/';
     }
-    std::string stm = side==WHITE?"w":"b";
-    std::string cast="";
-    if(castling_rights&1) cast+='K';
-    if(castling_rights&2) cast+='Q';
-    if(castling_rights&4) cast+='k';
-    if(castling_rights&8) cast+='q';
-    if(cast.empty()) cast="-";
-    std::string ep = en_passant==-1?"-":std::string(1,'a'+(en_passant%8))+std::to_string(en_passant/8+1);
-    return board+" "+stm+" "+cast+" "+ep+" "+std::to_string(halfmove_clock)+" "+std::to_string(fullmove_number);
+    std::string stm = side == WHITE ? "w" : "b";
+    std::string cast = "";
+    if (castling_rights & 1) cast += 'K';
+    if (castling_rights & 2) cast += 'Q';
+    if (castling_rights & 4) cast += 'k';
+    if (castling_rights & 8) cast += 'q';
+    if (cast.empty()) cast = "-";
+    std::string ep =
+        en_passant == -1 ? "-" : std::string(1, 'a' + (en_passant % 8)) + std::to_string(en_passant / 8 + 1);
+    return board + " " + stm + " " + cast + " " + ep + " " + std::to_string(halfmove_clock) + " " +
+           std::to_string(fullmove_number);
 }

--- a/superengine/engine/position.h
+++ b/superengine/engine/position.h
@@ -1,18 +1,21 @@
 #pragma once
 #include <string>
+
 #include "bitboard.h"
-namespace movegen { struct Move; }
+namespace movegen {
+struct Move;
+}
 
 enum Color { WHITE = 0, BLACK = 1 };
 enum Piece { PAWN = 0, KNIGHT, BISHOP, ROOK, QUEEN, KING, PIECE_NB };
 
 struct Position {
-    Bitboard piece_bb[2][PIECE_NB]{}; // [color][piece]
+    Bitboard piece_bb[2][PIECE_NB]{};  // [color][piece]
     Bitboard occupied_bb[2]{};
     Bitboard all_occupied{};
     Color side{};
-    uint8_t castling_rights{}; // bit0=K, bit1=Q, bit2=k, bit3=q
-    int8_t en_passant{-1};    // -1 if none
+    uint8_t castling_rights{};  // bit0=K, bit1=Q, bit2=k, bit3=q
+    int8_t en_passant{-1};      // -1 if none
     int halfmove_clock{};
     int fullmove_number{1};
 

--- a/superengine/engine/search.cpp
+++ b/superengine/engine/search.cpp
@@ -1,25 +1,25 @@
 #include "search.h"
-#include "nnue_eval.h"
+
 #include <algorithm>
 
-static const int MVV[6] = {100,320,330,500,900,20000};
+#include "nnue_eval.h"
+
+static const int MVV[6] = {100, 320, 330, 500, 900, 20000};
 
 constexpr int INF = 32000;
 
-int Search::search(Position& pos, int depth){
-    return pv_node(pos, -INF, INF, depth);
-}
+int Search::search(Position& pos, int depth) { return pv_node(pos, -INF, INF, depth); }
 
-int Search::search(Position& pos, const Limits& limits){
+int Search::search(Position& pos, const Limits& limits) {
     limits_ = limits;
     nodes_ = 0;
     start_ = std::chrono::steady_clock::now();
     int best = 0;
-    for(int d=1;;++d){
+    for (int d = 1;; ++d) {
         int score = pv_node(pos, -INF, INF, d);
-        if(!stop()) best = score;
-        if(stop()) break;
-        if(limits.nodes==0 && limits.time_ms==0) break; // fallback
+        if (!stop()) best = score;
+        if (stop()) break;
+        if (limits.nodes == 0 && limits.time_ms == 0) break;  // fallback
     }
     return best;
 }
@@ -30,23 +30,20 @@ int Search::pv_node(Position& pos, int alpha, int beta, int depth) {
 
     auto key = pos.to_fen();
     auto it = tt.find(key);
-    if(it != tt.end() && it->second.depth >= depth)
-        return it->second.score;
+    if (it != tt.end() && it->second.depth >= depth) return it->second.score;
 
     auto moves = movegen::generate_legal_moves(pos);
-    if(moves.empty())
-        return pos.in_check(pos.side) ? -INF + depth : 0;
+    if (moves.empty()) return pos.in_check(pos.side) ? -INF + depth : 0;
 
-    if (depth <= 0)
-        return quiesce(pos, alpha, beta);
+    if (depth <= 0) return quiesce(pos, alpha, beta);
 
-    if(depth >= 3 && !pos.in_check(pos.side)){
+    if (depth >= 3 && !pos.in_check(pos.side)) {
         Position null = pos;
-        null.side = pos.side==WHITE?BLACK:WHITE;
+        null.side = pos.side == WHITE ? BLACK : WHITE;
         null.en_passant = -1;
-        int score = -pv_node(null, -beta, -beta+1, depth-3);
-        if(score >= beta){
-            store_tt(key,{depth,score});
+        int score = -pv_node(null, -beta, -beta + 1, depth - 3);
+        if (score >= beta) {
+            store_tt(key, {depth, score});
             return score;
         }
     }
@@ -55,33 +52,29 @@ int Search::pv_node(Position& pos, int alpha, int beta, int depth) {
     if (eval >= beta) return eval;
 
     moves = movegen::generate_moves(pos);
-    std::vector<std::pair<int,movegen::Move>> scored;
+    std::vector<std::pair<int, movegen::Move>> scored;
     scored.reserve(moves.size());
-    for(const auto& m: moves){
+    for (const auto& m : moves) {
         int score = 0;
         Piece capture = pos.piece_on(m.to);
         Piece piece = pos.piece_on(m.from);
-        if(capture != PIECE_NB)
-            score += 10 * MVV[capture] - MVV[piece];
-        if(killer_[0][depth].from==m.from && killer_[0][depth].to==m.to)
-            score += 9000;
-        if(killer_[1][depth].from==m.from && killer_[1][depth].to==m.to)
-            score += 8000;
+        if (capture != PIECE_NB) score += 10 * MVV[capture] - MVV[piece];
+        if (killer_[0][depth].from == m.from && killer_[0][depth].to == m.to) score += 9000;
+        if (killer_[1][depth].from == m.from && killer_[1][depth].to == m.to) score += 8000;
         score += history_[m.from][m.to];
-        scored.push_back({score,m});
+        scored.push_back({score, m});
     }
-    std::sort(scored.begin(), scored.end(), [](auto& a, auto& b){return a.first>b.first;});
+    std::sort(scored.begin(), scored.end(), [](auto& a, auto& b) { return a.first > b.first; });
     for (size_t i = 0; i < scored.size(); ++i) {
         auto m = scored[i].second;
         Position next = pos;
         next.do_move(m);
         int score;
-        if(i >= 3 && depth >= 3){
-            score = -pv_node(next, -alpha-1, -alpha, depth-2);
-            if(score > alpha)
-                score = -pv_node(next, -beta, -alpha, depth-1);
-        }else{
-            score = -pv_node(next, -beta, -alpha, depth-1);
+        if (i >= 3 && depth >= 3) {
+            score = -pv_node(next, -alpha - 1, -alpha, depth - 2);
+            if (score > alpha) score = -pv_node(next, -beta, -alpha, depth - 1);
+        } else {
+            score = -pv_node(next, -beta, -alpha, depth - 1);
         }
         if (score >= beta) {
             killer_[1][depth] = killer_[0][depth];
@@ -99,45 +92,44 @@ int Search::pv_node(Position& pos, int alpha, int beta, int depth) {
     return alpha;
 }
 
-int Search::quiesce(Position& pos, int alpha, int beta){
+int Search::quiesce(Position& pos, int alpha, int beta) {
     ++nodes_;
-    if(stop()) return nnue::eval(pos);
+    if (stop()) return nnue::eval(pos);
 
     int stand_pat = nnue::eval(pos);
-    if(stand_pat >= beta) return beta;
-    if(stand_pat > alpha) alpha = stand_pat;
+    if (stand_pat >= beta) return beta;
+    if (stand_pat > alpha) alpha = stand_pat;
 
     auto moves = movegen::generate_moves(pos);
-    for(const auto& m: moves){
+    for (const auto& m : moves) {
         Piece capture = pos.piece_on(m.to);
-        if(capture == PIECE_NB) continue; // only captures
+        if (capture == PIECE_NB) continue;  // only captures
         Position next = pos;
         next.do_move(m);
-        if(next.in_check(pos.side)) continue;
+        if (next.in_check(pos.side)) continue;
         int score = -quiesce(next, -beta, -alpha);
-        if(score >= beta) return score;
-        if(score > alpha) alpha = score;
+        if (score >= beta) return score;
+        if (score > alpha) alpha = score;
     }
     return alpha;
 }
 
 bool Search::stop() const {
-    if(limits_.nodes && nodes_ >= limits_.nodes) return true;
-    if(limits_.time_ms){
-        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::steady_clock::now()-start_).count();
-        if(elapsed >= limits_.time_ms) return true;
+    if (limits_.nodes && nodes_ >= limits_.nodes) return true;
+    if (limits_.time_ms) {
+        auto elapsed =
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_).count();
+        if (elapsed >= limits_.time_ms) return true;
     }
     return false;
 }
 
-void Search::store_tt(const std::string& key, TTEntry entry){
+void Search::store_tt(const std::string& key, TTEntry entry) {
     auto it = tt.find(key);
-    if(it == tt.end()){
-        if(tt.size() >= TT_MAX)
-            tt.erase(tt.begin());
+    if (it == tt.end()) {
+        if (tt.size() >= TT_MAX) tt.erase(tt.begin());
         tt.emplace(key, entry);
-    }else if(entry.depth >= it->second.depth){
+    } else if (entry.depth >= it->second.depth) {
         it->second = entry;
     }
 }

--- a/superengine/engine/search.h
+++ b/superengine/engine/search.h
@@ -1,12 +1,15 @@
 #pragma once
-#include "position.h"
-#include "movegen.h"
-
-#include <unordered_map>
 #include <chrono>
 #include <cstddef>
+#include <unordered_map>
 
-struct TTEntry { int depth; int score; };
+#include "movegen.h"
+#include "position.h"
+
+struct TTEntry {
+    int depth;
+    int score;
+};
 
 struct Limits {
     int time_ms{0};
@@ -14,11 +17,11 @@ struct Limits {
 };
 
 class Search {
-public:
+   public:
     int search(Position& pos, int depth);
     int search(Position& pos, const Limits& limits);
 
-private:
+   private:
     int pv_node(Position& pos, int alpha, int beta, int depth);
     int quiesce(Position& pos, int alpha, int beta);
     bool stop() const;

--- a/superengine/engine/uci.cpp
+++ b/superengine/engine/uci.cpp
@@ -1,7 +1,8 @@
 #include <iostream>
 #include <sstream>
-#include "search.h"
+
 #include "movegen.h"
+#include "search.h"
 
 void uci_loop() {
     std::string cmd;
@@ -12,46 +13,59 @@ void uci_loop() {
             std::cout << "id name SuperEngine\nuciok\n";
         } else if (cmd == "isready") {
             std::cout << "readyok\n";
-        } else if (cmd.rfind("position",0)==0) {
-            auto rest = cmd.substr(8); // skip "position"
+        } else if (cmd.rfind("position", 0) == 0) {
+            auto rest = cmd.substr(8);  // skip "position"
             std::istringstream ss(rest);
             std::string token;
             ss >> token;
-            if(token == "startpos"){
+            if (token == "startpos") {
                 pos = Position("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
-                if(ss >> token && token == "moves"){
-                    while(ss >> token){
+                if (ss >> token && token == "moves") {
+                    while (ss >> token) {
                         movegen::Move m;
-                        m.from = (token[0]-'a') + (token[1]-'1')*8;
-                        m.to   = (token[2]-'a') + (token[3]-'1')*8;
+                        m.from = (token[0] - 'a') + (token[1] - '1') * 8;
+                        m.to = (token[2] - 'a') + (token[3] - '1') * 8;
                         m.promo = 0;
-                        if(token.size()==5){
-                            switch(token[4]){case 'q':m.promo=QUEEN;break;case 'r':m.promo=ROOK;break;case 'b':m.promo=BISHOP;break;case 'n':m.promo=KNIGHT;break;}
+                        if (token.size() == 5) {
+                            switch (token[4]) {
+                                case 'q':
+                                    m.promo = QUEEN;
+                                    break;
+                                case 'r':
+                                    m.promo = ROOK;
+                                    break;
+                                case 'b':
+                                    m.promo = BISHOP;
+                                    break;
+                                case 'n':
+                                    m.promo = KNIGHT;
+                                    break;
+                            }
                         }
                         pos.do_move(m);
                     }
                 }
-            } else if(token == "fen") {
+            } else if (token == "fen") {
                 std::string fen;
                 std::getline(ss, fen);
                 fen.erase(0, fen.find_first_not_of(' '));
                 pos = Position(fen);
             }
-        } else if (cmd.rfind("go",0)==0) {
+        } else if (cmd.rfind("go", 0) == 0) {
             auto moves = movegen::generate_moves(pos);
             movegen::Move best{};
             int bestScore = -32000;
-            for(const auto& m : moves){
+            for (const auto& m : moves) {
                 Position next = pos;
                 next.do_move(m);
                 int score = -search.search(next, 3);
-                if(score > bestScore){
+                if (score > bestScore) {
                     bestScore = score;
                     best = m;
                 }
             }
             char promoChar = 0;
-            if(best.promo){
+            if (best.promo) {
                 promoChar = " nbrq"[best.promo];
             }
             std::string uci;
@@ -59,7 +73,7 @@ void uci_loop() {
             uci += char('1' + best.from / 8);
             uci += char('a' + best.to % 8);
             uci += char('1' + best.to / 8);
-            if(promoChar) uci += promoChar;
+            if (promoChar) uci += promoChar;
             std::cout << "bestmove " << uci << "\n";
         } else if (cmd == "quit") {
             break;

--- a/superengine/tests/perft.cpp
+++ b/superengine/tests/perft.cpp
@@ -1,26 +1,26 @@
 #include <catch2/catch_test_macros.hpp>
-#include "position.h"
+
 #include "movegen.h"
+#include "position.h"
 
 using namespace movegen;
 
-static uint64_t perft(Position& pos, int depth){
-    if(depth==0) return 1;
+static uint64_t perft(Position& pos, int depth) {
+    if (depth == 0) return 1;
     auto moves = generate_pseudo_legal(pos);
     uint64_t nodes = 0;
-    for(const auto& m : moves){
+    for (const auto& m : moves) {
         Position next = pos;
         next.do_move(m);
-        nodes += perft(next, depth-1);
+        nodes += perft(next, depth - 1);
     }
     return nodes;
 }
 
-TEST_CASE("Perft startpos", "[perft]"){
+TEST_CASE("Perft startpos", "[perft]") {
     init_attack_tables();
     Position pos("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
-    REQUIRE(perft(pos,1) == 20);
-    REQUIRE(perft(pos,2) == 400);
-    REQUIRE(perft(pos,3) == 8902);
+    REQUIRE(perft(pos, 1) == 20);
+    REQUIRE(perft(pos, 2) == 400);
+    REQUIRE(perft(pos, 3) == 8902);
 }
-

--- a/superengine/tests/test_movegen.cpp
+++ b/superengine/tests/test_movegen.cpp
@@ -1,19 +1,21 @@
 #include <catch2/catch_test_macros.hpp>
-#include "position.h"
+
 #include "movegen.h"
+#include "position.h"
 
 TEST_CASE("Start position pseudo pawn+knight", "[movegen]") {
     Position pos("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
     auto moves = movegen::generate_pawn_knight(pos);
-    REQUIRE(moves.size() == 20); // 16 pawn pushes + 4 knight moves
+    REQUIRE(moves.size() == 20);  // 16 pawn pushes + 4 knight moves
 }
 
 TEST_CASE("White pawn double push", "[movegen]") {
     Position pos("8/8/8/8/8/8/PPPPPPPP/8 w - - 0 1");
     auto moves = movegen::generate_pawn_knight(pos);
     int pawn_moves = 0;
-    for(auto m: moves) if(m.from>=8 && m.from<16) pawn_moves++;
-    REQUIRE(pawn_moves == 16); // 8 single + 8 double
+    for (auto m : moves)
+        if (m.from >= 8 && m.from < 16) pawn_moves++;
+    REQUIRE(pawn_moves == 16);  // 8 single + 8 double
 }
 
 TEST_CASE("Knight on d4", "[movegen]") {
@@ -26,9 +28,8 @@ TEST_CASE("En passant generation", "[movegen]") {
     Position pos("rnbqkb1r/ppp1pppp/5n2/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3");
     auto moves = movegen::generate_pseudo_moves(pos);
     bool found = false;
-    for(const auto& m : moves)
-        if(m.from == 36 && m.to == 43)
-            found = true;
+    for (const auto& m : moves)
+        if (m.from == 36 && m.to == 43) found = true;
     REQUIRE(found);
 }
 
@@ -40,7 +41,7 @@ TEST_CASE("Start position legal move count", "[movegen]") {
 
 TEST_CASE("Castling move updates board", "[movegen]") {
     Position pos("r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1");
-    movegen::Move castle{4,6,0};
+    movegen::Move castle{4, 6, 0};
     pos.do_move(castle);
     REQUIRE(pos.piece_on(6) == KING);
     REQUIRE(pos.piece_on(5) == ROOK);

--- a/superengine/tests/test_nnue.cpp
+++ b/superengine/tests/test_nnue.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+
 #include "nnue_eval.h"
 #include "position.h"
 

--- a/superengine/tests/test_position.cpp
+++ b/superengine/tests/test_position.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+
 #include "position.h"
 
 TEST_CASE("Fen parsing extras", "[position]") {
@@ -14,8 +15,8 @@ TEST_CASE("Fen parsing extras", "[position]") {
 
 TEST_CASE("Fen with en passant target", "[position]") {
     Position pos("rnbqkbnr/pppppppp/8/8/8/4P3/PPPP1PPP/RNBQKBNR b KQkq e3 0 1");
-    REQUIRE(pos.en_passant == 20); // e3 square index
+    REQUIRE(pos.en_passant == 20);  // e3 square index
     REQUIRE(pos.side_to_move() == BLACK);
     REQUIRE(pos.castling_rights == 0b1111);
-    REQUIRE(pos.piece_on(20) == PAWN); // white pawn on e3
+    REQUIRE(pos.piece_on(20) == PAWN);  // white pawn on e3
 }

--- a/superengine/tests/test_search.cpp
+++ b/superengine/tests/test_search.cpp
@@ -1,14 +1,15 @@
 #include <catch2/catch_test_macros.hpp>
-#include "position.h"
+
 #include "movegen.h"
+#include "position.h"
 #include "search.h"
 
-TEST_CASE("Mate in one", "[search]"){
+TEST_CASE("Mate in one", "[search]") {
     movegen::init_attack_tables();
     Position pos("7k/6Q1/7K/8/8/8/8/8 w - - 0 1");
     Search s;
-    Limits lim; lim.nodes = 10000; // sufficient
+    Limits lim;
+    lim.nodes = 10000;  // sufficient
     int score = s.search(pos, lim);
     REQUIRE(score > 30000);
 }
-

--- a/superengine/tests/test_sliding.cpp
+++ b/superengine/tests/test_sliding.cpp
@@ -1,26 +1,30 @@
 #include <catch2/catch_test_macros.hpp>
-#include "position.h"
+
 #include "movegen.h"
+#include "position.h"
 
 using namespace movegen;
 
 TEST_CASE("Bishop moves on empty board", "[sliding]") {
     init_attack_tables();
     Position pos("8/8/8/3B4/8/8/8/8 w - - 0 1");
-    MoveList ml; generate_bishop_moves(pos, ml);
+    MoveList ml;
+    generate_bishop_moves(pos, ml);
     REQUIRE(ml.size() == 13);
 }
 
 TEST_CASE("Rook moves on empty board", "[sliding]") {
     init_attack_tables();
     Position pos("8/8/8/3R4/8/8/8/8 w - - 0 1");
-    MoveList ml; generate_rook_moves(pos, ml);
+    MoveList ml;
+    generate_rook_moves(pos, ml);
     REQUIRE(ml.size() == 14);
 }
 
 TEST_CASE("Queen moves on empty board", "[sliding]") {
     init_attack_tables();
     Position pos("8/8/8/3Q4/8/8/8/8 w - - 0 1");
-    MoveList ml; generate_queen_moves(pos, ml);
+    MoveList ml;
+    generate_queen_moves(pos, ml);
     REQUIRE(ml.size() == 27);
 }


### PR DESCRIPTION
## Summary
- enforce clang-format with `.clang-format`
- add GitHub workflow for C++ build, test, and coverage
- enable sanitizer and coverage flags in `superengine` CMake
- document GPU setup for unsupported GPUs
- update roadmap

## Testing
- `clang-format` run with no violations
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b44ecf708325ab12ad226ab509ff