### PR TITLE
Enable GPU device

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Während des Trainings erscheinen nun kurze Statistiken zu jedem Epoch.
 
 ### GPU Setup
 
+Der Parameter ``Config.DEVICE`` wählt nun automatisch ``"cuda:0"`` aus, wenn
+eine kompatible GPU verfügbar ist. Damit läuft das Training direkt auf der RTX
+5070 oder anderen CUDA-Geräten.
+
 Falls deine GPU von der offiziellen PyTorch-Distribution nicht unterstützt wird,
 musst du PyTorch selbst kompilieren. Setze dazu beispielsweise
 

--- a/chess_ai/config.py
+++ b/chess_ai/config.py
@@ -8,7 +8,12 @@ class Config:
     WANDB_PROJECT = "chess-ai"
 
     # Hardware
-    DEVICE = "cuda" if __import__('torch').cuda.is_available() else "cpu"
+    # Always prefer CUDA when available so the network trains on GPUs like the
+    # RTX 5070.  A ``torch.device`` object is used to avoid string/device
+    # mismatches across the codebase.
+    DEVICE = __import__("torch").device(
+        "cuda:0" if __import__("torch").cuda.is_available() else "cpu"
+    )
     SEED = 42
 
     # MCTS parameters


### PR DESCRIPTION
## Summary
- default to CUDA when available using `torch.device`
- note new automatic GPU selection in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c53b26808325ba2642d8b8a9549f