### PR TITLE
Fix make not found issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ demonstrieren.
 
 Dies installiert alle Python-Abhängigkeiten und baut standardmäßig auch die C++
 Engine in `superengine/`. Zusätzlich wird das Projekt selbst im
-Entwicklungsmodus installiert.
+Entwicklungsmodus installiert. Das Skript prüft dabei, ob ein
+`make`-Kommando verfügbar ist. Fehlt es, versucht es automatisch die nötigen
+Build-Werkzeuge zu installieren – unter Linux per `apt`, unter Windows über
+`Chocolatey` (wird bei Bedarf ebenfalls installiert).
 Wer nur die Python-Funktionalität benötigt, kann stattdessen einfach
 
 ```bash

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,30 @@
 #!/usr/bin/env bash
 set -e
 
+install_make() {
+  if command -v make >/dev/null 2>&1; then
+    return
+  fi
+
+  echo "make not found. Attempting to install build tools..."
+  case "$(uname -s)" in
+    Linux*)
+      if command -v apt-get >/dev/null 2>&1; then
+        sudo apt-get update
+        sudo apt-get install -y build-essential make
+      fi
+      ;;
+    MINGW*|MSYS*|CYGWIN*)
+      if ! command -v choco >/dev/null 2>&1; then
+        echo "Chocolatey not found. Installing..."
+        powershell -NoProfile -ExecutionPolicy Bypass -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))"
+        export PATH="$PATH:/c/ProgramData/chocolatey/bin"
+      fi
+      choco install -y make
+      ;;
+  esac
+}
+
 # Install Python dependencies
 if [ -f "requirements.txt" ]; then
   echo "Installing Python requirements..."
@@ -8,11 +32,13 @@ if [ -f "requirements.txt" ]; then
   pip install -e .
 fi
 
+install_make
+
 # Optional build of the C++ superengine
 if [ -d "superengine" ]; then
   echo "Building superengine..."
   cd superengine
-  make -j$(nproc)
+  make -j"$(nproc)"
   cd ..
 fi
 


### PR DESCRIPTION
## Summary
- improve install.sh to auto-install `make` via apt or Chocolatey
- clarify in README that the script installs build tools if necessary

## Testing
- `shellcheck scripts/install.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68483a411cc48325839f3c47a06da9e2