### PR TITLE
Implement monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,4 +228,10 @@ Repository verfolgen kannst.
 - [x] C++‑CI: cmake + ctest + clang‑format + Sanitizer
 - [x] Dockerfiles (C++ & Python)
 - [x] Kubernetes‑Manifeste (Deployment, CronJob)
-- [ ] Monitoring (Prometheus, Grafana)
+- [x] Monitoring (Prometheus, Grafana)
+
+#### Monitoring-Setup
+
+Prometheus liest die Metriken der Flask-App über `/metrics` aus. Die nötigen
+Kubernetes-Ressourcen befinden sich in `k8s/prometheus.yaml` und
+`k8s/grafana.yaml`.

--- a/chess_ai/self_play.py
+++ b/chess_ai/self_play.py
@@ -1,9 +1,16 @@
 import numpy as np
 
+from prometheus_client import Counter
+
 from .game_environment import GameEnvironment
 from .mcts import MCTS
 from .config import Config
 from .action_index import ACTION_SIZE, index_to_move
+
+# Metric to count completed self-play games
+self_play_games_total = Counter(
+    "self_play_games_total", "Number of self-play games generated"
+)
 
 
 def run_self_play(network, num_simulations: int = Config.NUM_SIMULATIONS):
@@ -38,6 +45,7 @@ def run_self_play(network, num_simulations: int = Config.NUM_SIMULATIONS):
             for s, p, player in trajectory:
                 z = reward if player == current_player else -reward
                 yield s, p, z
+            self_play_games_total.inc()
             break
         current_player *= -1
 

--- a/k8s/grafana.yaml
+++ b/k8s/grafana.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+      - name: grafana
+        image: grafana/grafana
+        ports:
+        - containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+spec:
+  selector:
+    app: grafana
+  ports:
+  - port: 3000
+    targetPort: 3000

--- a/k8s/prometheus.yaml
+++ b/k8s/prometheus.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+    scrape_configs:
+      - job_name: 'chess-ai'
+        static_configs:
+          - targets: ['chess-ai:80']
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+      - name: prometheus
+        image: prom/prometheus
+        args:
+          - '--config.file=/etc/prometheus/prometheus.yml'
+        ports:
+        - containerPort: 9090
+        volumeMounts:
+        - name: config
+          mountPath: /etc/prometheus
+      volumes:
+      - name: config
+        configMap:
+          name: prometheus-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  selector:
+    app: prometheus
+  ports:
+  - port: 9090
+    targetPort: 9090

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "python-chess",
     "numpy",
     "lmdb",
+    "prometheus_client",
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ black
 flake8
 isort
 coverage
+prometheus_client

--- a/scripts/serve.py
+++ b/scripts/serve.py
@@ -1,17 +1,22 @@
-from flask import Flask
+from flask import Flask, Response, request
 from chess_ai.policy_value_net import PolicyValueNet
 from chess_ai.game_environment import GameEnvironment
+from prometheus_client import Counter, generate_latest, CONTENT_TYPE_LATEST
+
+# Simple counter for Prometheus
+REQUEST_COUNT = Counter("requests_total", "HTTP requests", ["endpoint"])
 
 app = Flask(__name__)
 
 @app.get("/health")
 def health():
+    REQUEST_COUNT.labels(endpoint="health").inc()
     return {"status": "ok"}
 
 @app.get("/metrics")
 def metrics():
-    # placeholder metric
-    return {"games_played": 0}
+    REQUEST_COUNT.labels(endpoint="metrics").inc()
+    return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=8000)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,17 @@
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "serve", Path(__file__).resolve().parents[1] / "scripts" / "serve.py"
+)
+serve = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(serve)
+app = serve.app
+
+
+def test_metrics_endpoint_returns_prometheus_format():
+    with app.test_client() as client:
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+        # Prometheus metrics output should include HELP or TYPE lines
+        assert b"# TYPE" in resp.data or b"# HELP" in resp.data


### PR DESCRIPTION
## Summary
- add Prometheus metrics to `scripts/serve.py` and instrument self-play
- install `prometheus_client`
- provide Prometheus and Grafana manifests
- test metrics endpoint
- mark monitoring as done in README

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68496eeb55748325a19385dc3e2a59ab