### PR TITLE
Add ONNX export and runtime integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,19 @@ cd pytorch && python setup.py install
 Danach erkennt `torch.cuda.is_available()` die RTX 5070 korrekt und das Training
 nutzt die GPU.
 
+### ONNX Export
+
+Nach jedem Trainingslauf kannst du das Netzwerk als ONNX-Datei exportieren.
+
+```bash
+python3 python/scripts/export_onnx.py \
+  --ckpt models/model_iter_7.pt \
+  --out nets/policy_iter_7.onnx
+```
+
+Die resultierende `policy_iter_7.onnx` lässt sich anschließend in der
+C++-Engine mit ONNX Runtime laden.
+
 ### Gegen die KI spielen
 
 Nach dem Training kannst du mit folgendem Skript gegen das neueste Netz

--- a/python/scripts/export_onnx.py
+++ b/python/scripts/export_onnx.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+import torch
+from chess_ai.policy_value_net import PolicyValueNet
+from chess_ai.game_environment import GameEnvironment
+from chess_ai.action_index import ACTION_SIZE
+
+
+def main(ckpt_path: str, onnx_out: str):
+    # 1) Model reconstruction
+    model = PolicyValueNet(
+        GameEnvironment.NUM_CHANNELS,
+        ACTION_SIZE,
+    )
+    model.load_state_dict(torch.load(ckpt_path, map_location="cpu"))
+    model.eval()
+
+    # 2) Dummy input (Batch=1, Channels=18, 8x8)
+    dummy = torch.zeros(1, GameEnvironment.NUM_CHANNELS, 8, 8, dtype=torch.float32)
+
+    # 3) Export
+    torch.onnx.export(
+        model,
+        dummy,
+        onnx_out,
+        input_names=["input"],
+        output_names=["policy", "value"],
+        opset_version=13,
+        do_constant_folding=True,
+    )
+    print(f"\u2713  ONNX model written: {onnx_out}")
+
+
+if __name__ == "__main__":
+    import argparse
+    import pathlib
+
+    p = argparse.ArgumentParser()
+    p.add_argument("--ckpt", required=True)
+    p.add_argument("--out", default="policy.onnx")
+    args = p.parse_args()
+    pathlib.Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    main(args.ckpt, args.out)

--- a/superengine/CMakeLists.txt
+++ b/superengine/CMakeLists.txt
@@ -26,16 +26,18 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(Catch2)
 
 find_package(Threads REQUIRED)
+find_package(ONNXRuntime REQUIRED)
 
 add_library(engine
     engine/bitboard.cpp
     engine/movegen.cpp
     engine/position.cpp
     engine/nnue_eval.cpp
-    engine/search.cpp)
+    engine/search.cpp
+    engine/onnx_policy.cpp)
 
 target_include_directories(engine PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/engine)
-target_link_libraries(engine PUBLIC Threads::Threads)
+target_link_libraries(engine PUBLIC Threads::Threads onnxruntime)
 
 add_executable(test_movegen tests/test_movegen.cpp)
 target_link_libraries(test_movegen PRIVATE engine Catch2::Catch2WithMain)

--- a/superengine/engine/onnx_policy.cpp
+++ b/superengine/engine/onnx_policy.cpp
@@ -1,0 +1,30 @@
+#include "onnx_policy.h"
+
+OnnxPolicy::OnnxPolicy(const std::string& model)
+    : env_(ORT_LOGGING_LEVEL_WARNING, "super"),
+      session_(env_, model.c_str(), Ort::SessionOptions{nullptr}) {
+    input_names_.push_back(session_.GetInputNameAllocated(0, alloc_));
+    output_names_.push_back(session_.GetOutputNameAllocated(0, alloc_));
+    output_names_.push_back(session_.GetOutputNameAllocated(1, alloc_));
+}
+
+std::pair<std::array<float, 64>, float>
+OnnxPolicy::operator()(const std::array<float, 18 * 8 * 8>& feat) {
+    static Ort::MemoryInfo mem =
+        Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+
+    const int64_t shape[4] = {1, 18, 8, 8};
+    Ort::Value input = Ort::Value::CreateTensor<float>(
+        mem, const_cast<float*>(feat.data()), feat.size(), shape, 4);
+
+    auto outputs = session_.Run(Ort::RunOptions{nullptr}, input_names_.data(),
+                                &input, 1, output_names_.data(), 2);
+
+    auto* p_data = outputs[0].GetTensorMutableData<float>();
+    auto* v_data = outputs[1].GetTensorMutableData<float>();
+
+    std::array<float, 64> policy;
+    std::copy(p_data, p_data + 64, policy.begin());
+    float value = v_data[0];
+    return {policy, value};
+}

--- a/superengine/engine/onnx_policy.h
+++ b/superengine/engine/onnx_policy.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <array>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <onnxruntime_cxx_api.h>
+
+class OnnxPolicy {
+public:
+    explicit OnnxPolicy(const std::string& model);
+    std::pair<std::array<float, 64>, float>
+    operator()(const std::array<float, 18 * 8 * 8>& features);
+
+private:
+    Ort::Env env_;
+    Ort::Session session_;
+    Ort::AllocatorWithDefaultOptions alloc_;
+    std::vector<const char*> input_names_;
+    std::vector<const char*> output_names_;
+};


### PR DESCRIPTION
## Summary
- add export_onnx.py helper to create policy.onnx
- integrate ONNX Runtime with C++ engine
- provide OnnxPolicy wrapper for inference
- mention ONNX export in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chess_ai')*
- `pip install -q -r requirements.txt` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_6849b29464e083258f3dbb9a2aec1351