### PR TITLE
Fix quantize_nnue state key and train evaluation

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -94,15 +94,11 @@ def main(args):
         data = torch.load(old_ckpt, map_location=Config.DEVICE)
         old_net.load_state_dict(data["model_state"])
         stats = evaluate(
-
             net,
             old_net,
             num_games=1000,
             num_simulations=Config.NUM_SIMULATIONS,
             max_moves=60,
-
-            net, old_net, num_games=1000, num_simulations=Config.NUM_SIMULATIONS
-
         )
         print("Eval stats", stats)
         if sprt(stats["wins"], stats["losses"], stats["draws"]):

--- a/superengine/scripts/quantize_nnue.py
+++ b/superengine/scripts/quantize_nnue.py
@@ -36,6 +36,8 @@ def main():
     state = torch.load(args.model, map_location="cpu")
     if "state_dict" in state:
         state = state["state_dict"]
+    elif "model_state" in state:
+        state = state["model_state"]
     data = quantize_state_dict(state, args.scale)
     with open(args.output, "wb") as fh:
         fh.write(data)


### PR DESCRIPTION
## Summary
- fix syntax error in evaluation call in `scripts/train.py`
- allow `quantize_nnue` to load checkpoints saved with `model_state`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c69767a48325a9fb673ab0c31818