### PR TITLE
Clarify ONNX Runtime dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,13 @@ Per `--play-white` wählst du deine Farbe.
 ### C++-Engine nutzen
 
 Die Verzeichnisse unter `superengine/` enthalten eine experimentelle
-C++-Engine. Beim Aufruf von `./scripts/install.sh` wird sie automatisch mittels
-`cmake` kompiliert. Für einen manuellen Build wechselst du in das Verzeichnis
-`superengine` und führst aus:
+C++-Engine. Zum Bauen wird das native [ONNX Runtime](https://onnxruntime.ai)
+benötigt. Lade dazu das vorgefertigte C++ SDK herunter oder kompiliere es aus
+den Quellen und setze die Umgebungsvariable `ONNXRuntime_DIR` auf den Ordner,
+der die Datei `onnxruntimeConfig.cmake` enthält. Anschließend wird beim Aufruf
+von `./scripts/install.sh` die Engine automatisch mittels `cmake` kompiliert.
+Für einen manuellen Build wechselst du in das Verzeichnis `superengine` und
+führst aus:
 
 ```bash
 cd superengine

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,7 +14,12 @@ if [ -d "superengine" ]; then
   cd superengine
   mkdir -p build
   cd build
-  cmake ..
+  if [ -n "$ONNXRuntime_DIR" ]; then
+    echo "Using ONNXRuntime from $ONNXRuntime_DIR"
+    cmake .. -DONNXRuntime_DIR="$ONNXRuntime_DIR"
+  else
+    cmake ..
+  fi
 
   # Determine the number of parallel build jobs in a cross-platform way
   JOBS=1
@@ -24,11 +29,6 @@ if [ -d "superengine" ]; then
     JOBS=$(sysctl -n hw.ncpu)
   fi
   cmake --build . --parallel "$JOBS"
-
-
-  cmake --build . -- -j$(nproc)
-
-  make -j$(nproc)
 
 
   cd ../..


### PR DESCRIPTION
## Summary
- explain how to provide ONNX Runtime for the C++ engine
- allow passing `ONNXRuntime_DIR` to the installer

## Testing
- `pip install -q -r requirements.txt`
- `pip install -e . -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac4c6f9288325a09f946a320ba747