### PR TITLE
Improve quantization robustness

### DIFF
--- a/chess_ai/trainer.py
+++ b/chess_ai/trainer.py
@@ -37,9 +37,9 @@ class Trainer:
         if len(self.buffer) < self.batch_size:
             return
         states, policies, values = self.buffer.sample(self.batch_size)
-        states = torch.tensor(states, dtype=torch.float32, device=Config.DEVICE)
-        policies = torch.tensor(policies, dtype=torch.float32, device=Config.DEVICE)
-        values = torch.tensor(values, dtype=torch.float32, device=Config.DEVICE)
+        states = torch.tensor(states, dtype=torch.float32)
+        policies = torch.tensor(policies, dtype=torch.float32)
+        values = torch.tensor(values, dtype=torch.float32)
         dataset = TensorDataset(states, policies, values)
         loader = DataLoader(
             dataset,
@@ -52,9 +52,9 @@ class Trainer:
         for epoch in range(self.epochs):
             epoch_loss = 0.0
             for batch_idx, (s, p_target, v_target) in enumerate(loader):
-                s = s.to(Config.DEVICE)
-                p_target = p_target.to(Config.DEVICE)
-                v_target = v_target.to(Config.DEVICE)
+                s = s.to(Config.DEVICE, non_blocking=True)
+                p_target = p_target.to(Config.DEVICE, non_blocking=True)
+                v_target = v_target.to(Config.DEVICE, non_blocking=True)
                 log_p, v = self.network(s)
                 loss_policy = -(p_target * log_p).sum(dim=1).mean()
                 loss_value = torch.mean((v.view(-1) - v_target) ** 2)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -75,14 +75,18 @@ def main(args):
     trainer.train()
 
     new_ckpt = manager.save(net, optimizer, "latest")
-    subprocess.run(
-        [
-            "python",
-            "superengine/scripts/quantize_nnue.py",
-            new_ckpt,
-            f"superengine/nets/iter_latest.nnue",
-        ]
-    )
+    try:
+        subprocess.run(
+            [
+                "python",
+                "superengine/scripts/quantize_nnue.py",
+                new_ckpt,
+                "superengine/nets/iter_latest.nnue",
+            ],
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(f"Quantization failed: {exc}")
 
     if old_ckpt:
         old_net = PolicyValueNet(

--- a/tests/test_quantize_nnue.py
+++ b/tests/test_quantize_nnue.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+import torch
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "superengine", "scripts"))
+from quantize_nnue import quantize_state_dict
+
+
+def _dummy_state_dict(use_old_names=False):
+    state = {}
+    if use_old_names:
+        state["l1.weight"] = torch.ones(256, 64)
+        state["l1.bias"] = torch.zeros(256)
+        state["l2.weight"] = torch.ones(1, 256)
+        state["l2.bias"] = torch.zeros(1)
+        state["out.weight"] = torch.ones(10, 128)
+        state["out.bias"] = torch.zeros(10)
+    else:
+        state["fc_value1.weight"] = torch.ones(256, 64)
+        state["fc_value1.bias"] = torch.zeros(256)
+        state["fc_value2.weight"] = torch.ones(1, 256)
+        state["fc_value2.bias"] = torch.zeros(1)
+        state["fc_policy.weight"] = torch.ones(10, 128)
+        state["fc_policy.bias"] = torch.zeros(10)
+    return state
+
+
+def test_quantize_new_names():
+    sd = _dummy_state_dict()
+    data = quantize_state_dict(sd)
+    expected_size = (256 * 64 + 256 + 1 * 256 + 1 + 10 * 128 + 10) * 2
+    assert len(data) == expected_size
+
+
+def test_quantize_old_names():
+    sd = _dummy_state_dict(use_old_names=True)
+    data = quantize_state_dict(sd)
+    expected_size = (256 * 64 + 256 + 1 * 256 + 1 + 10 * 128 + 10) * 2
+    assert len(data) == expected_size


### PR DESCRIPTION
## Summary
- support old layer names when exporting NNUE weights
- handle quantization errors gracefully in training script
- keep data on CPU so DataLoader can pin memory and move to GPU asynchronously
- add tests for quantization helper

## Testing
- `pip install torch==2.3.0+cpu torchvision==0.18.0+cpu --index-url https://download.pytorch.org/whl/cpu`
- `pip install python-chess flask numpy lmdb tensorboard wandb black flake8 isort coverage prometheus_client`
- `pip install -e . --no-deps`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ad5b0b71c83259f8a6d8fc35a1eff