### PR TITLE
Fix evaluate import

### DIFF
--- a/chess_ai/trainer.py
+++ b/chess_ai/trainer.py
@@ -14,9 +14,7 @@ except Exception:  # pragma: no cover - optional dependency
     ORTModule = None
 import wandb
 from tqdm.auto import tqdm
-import sys
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "scripts"))
-from play_vs_ai import evaluate_against_previous
+from scripts.play_vs_ai import evaluate_against_previous
 
 torch.backends.cudnn.benchmark = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,4 @@ dependencies = [
 
 
 [tool.setuptools.packages.find]
-include = ["chess_ai*"]
+include = ["chess_ai*", "scripts*"]


### PR DESCRIPTION
## Summary
- package scripts so it can be imported
- adjust trainer to import evaluate function from scripts

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c2b4e4d9883258ba9f3d75e91a232