### PR TITLE
Handle wrapped models when saving

### DIFF
--- a/chess_ai/network_manager.py
+++ b/chess_ai/network_manager.py
@@ -6,6 +6,15 @@ import torch
 from .config import Config
 
 
+def _unwrap(model):
+    """Return the underlying PyTorch module for wrapped/compiled models."""
+    if hasattr(model, "_orig_mod"):
+        return model._orig_mod
+    if hasattr(model, "_original_module"):
+        return model._original_module
+    return model
+
+
 class NetworkManager:
     def __init__(self, checkpoint_dir: str = Config.CHECKPOINT_DIR):
         self.checkpoint_dir = checkpoint_dir
@@ -19,13 +28,21 @@ class NetworkManager:
 
     def save(self, model, optimizer, name):
         path = os.path.join(self.checkpoint_dir, f"{name}.pt")
-        torch.save({"model_state": model.state_dict(), "optim_state": optimizer.state_dict()}, path)
+        base_model = _unwrap(model)
+        torch.save(
+            {
+                "model_state": base_model.state_dict(),
+                "optim_state": optimizer.state_dict(),
+            },
+            path,
+        )
         return path
 
     def load(self, path, model, optimizer=None):
         """Load a checkpoint into ``model`` and optionally ``optimizer``."""
         checkpoint = torch.load(path, map_location=Config.DEVICE)
-        model.load_state_dict(checkpoint["model_state"])
+        base_model = _unwrap(model)
+        base_model.load_state_dict(checkpoint["model_state"])
         if optimizer and "optim_state" in checkpoint:
             optimizer.load_state_dict(checkpoint["optim_state"])
         return checkpoint

--- a/superengine/scripts/quantize_nnue.py
+++ b/superengine/scripts/quantize_nnue.py
@@ -1,7 +1,6 @@
 import argparse
 import numpy as np
 import torch
-from tqdm.auto import tqdm
 
 
 def _get_param(state_dict: dict, *names: str):
@@ -57,7 +56,8 @@ def quantize_state_dict(state_dict: dict, scale: int = 1000) -> bytes:
         b3_q.tobytes(),
     ]
     packed = bytearray()
-    for part in tqdm(parts, desc="Packe Daten", unit="chunk"):
+    for idx, part in enumerate(parts, 1):
+        print(f"Packe Daten Chunk {idx}/{len(parts)}")
         packed.extend(part)
     return bytes(packed)
 


### PR DESCRIPTION
## Summary
- ensure NetworkManager saves and loads using unwrapped modules
- persist checkpoints from Trainer without compiled wrappers
- simplify NNUE quantization progress messages
- remove unused tqdm import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_684c586ee3f08325b12be40b4030b94c