### PR TITLE
Handle legacy _orig_mod checkpoints

### DIFF
--- a/scripts/play_vs_ai.py
+++ b/scripts/play_vs_ai.py
@@ -24,8 +24,7 @@ def load_network(manager: NetworkManager) -> PolicyValueNet:
     ckpt = manager.latest_checkpoint()
     if not ckpt:
         raise FileNotFoundError("No trained network found in checkpoints")
-    data = torch.load(ckpt, map_location=Config.DEVICE)
-    net.load_state_dict(data["model_state"])
+    manager.load(ckpt, net)
     net.eval()
     return net
 
@@ -43,8 +42,7 @@ def evaluate_against_previous(prev_ckpt: str, games: int = 100, simulations: int
         num_blocks=Config.NUM_RES_BLOCKS,
         filters=Config.NUM_FILTERS,
     ).to(Config.DEVICE)
-    data = torch.load(latest_ckpt, map_location=Config.DEVICE)
-    new_net.load_state_dict(data["model_state"])
+    manager.load(latest_ckpt, new_net)
 
     old_net = PolicyValueNet(
         GameEnvironment.NUM_CHANNELS,
@@ -52,8 +50,7 @@ def evaluate_against_previous(prev_ckpt: str, games: int = 100, simulations: int
         num_blocks=Config.NUM_RES_BLOCKS,
         filters=Config.NUM_FILTERS,
     ).to(Config.DEVICE)
-    data_old = torch.load(prev_ckpt, map_location=Config.DEVICE)
-    old_net.load_state_dict(data_old["model_state"])
+    manager.load(prev_ckpt, old_net)
 
     stats = evaluate(
         new_net,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -60,9 +60,7 @@ def load_or_initialize_network(manager: NetworkManager):
     )
     ckpt = manager.latest_checkpoint()
     if ckpt:
-        data = torch.load(ckpt, map_location=Config.DEVICE)
-        net.load_state_dict(data["model_state"])
-        optimizer.load_state_dict(data["optim_state"])
+        manager.load(ckpt, net, optimizer)
     return net, optimizer
 
 

--- a/tests/test_network_manager.py
+++ b/tests/test_network_manager.py
@@ -1,0 +1,21 @@
+import torch
+from chess_ai.network_manager import NetworkManager
+from chess_ai.policy_value_net import PolicyValueNet
+from chess_ai.action_index import ACTION_SIZE
+from chess_ai.game_environment import GameEnvironment
+
+
+def test_load_handles_orig_mod_prefix(tmp_path):
+    manager = NetworkManager(checkpoint_dir=tmp_path)
+    net = PolicyValueNet(GameEnvironment.NUM_CHANNELS, ACTION_SIZE, num_blocks=1, filters=8)
+    optim = torch.optim.SGD(net.parameters(), lr=0.1)
+    path = manager.save(net, optim, "test")
+    data = torch.load(path)
+    # simulate old checkpoint with _orig_mod prefix
+    data["model_state"] = {f"_orig_mod.{k}": v for k, v in data["model_state"].items()}
+    torch.save(data, path)
+
+    loaded = manager.load(path, net, optim)
+    assert isinstance(loaded, dict)
+    expected_keys = set(k[len("_orig_mod."):] if k.startswith("_orig_mod.") else k for k in data["model_state"]) 
+    assert set(net.state_dict().keys()) == expected_keys


### PR DESCRIPTION
## Summary
- fix NetworkManager to load checkpoints saved before unwrap change
- use NetworkManager.load when restoring networks
- add regression test for legacy checkpoint loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d66dc56b88325ac92b6aa587980a8