### PR TITLE
Fix compile fallback

### DIFF
--- a/chess_ai/trainer.py
+++ b/chess_ai/trainer.py
@@ -66,8 +66,10 @@ class Trainer:
         log_dir: str = Config.LOG_DIR,
         use_wandb: bool = False,
     ):
+        # 1) Auf GPU schieben …
         self.network = network.to(Config.DEVICE)
-        self.network = torch.compile(self.network)
+        # 2) TorchDynamo ohne Triton, mit aot_eager-Fallback:
+        self.network = torch.compile(self.network, backend="aot_eager")
         if ORTModule is not None:
             self.network = ORTModule(self.network)
         # Gradient checkpointing handled inside the network's forward


### PR DESCRIPTION
## Summary
- avoid Triton dependency in trainer by using `torch.compile(..., backend="aot_eager")`

## Testing
- `flake8 chess_ai scripts tests`
- `black --check chess_ai scripts tests` *(fails: would reformat many files)*
- `isort --check chess_ai scripts tests` *(fails: imports are incorrectly sorted)*
- `pytest -q` *(fails: missing dependencies such as torch, numpy, flask)*

------
https://chatgpt.com/codex/tasks/task_e_684d75e101448325a8eb75066da254ab